### PR TITLE
Fix log scale death toll

### DIFF
--- a/coronavirus.py
+++ b/coronavirus.py
@@ -563,9 +563,16 @@ def make_compare_plot_germany(region_subregion,
                       "daily new cases\n(rolling 7-day mean)",
                       v0=v0c, highlight={res_c.columns[0]:"C1"}, labeloffset=0.5)
     ax = axes[1]
+
+    res_d_0 = res_d[res_d.index >= 0]   # from "day 0" only
+    # if we have values in between 0.1 and 1, set the lower `y_limit` on the graph to 0.1
+    if res_d_0[(res_d_0 > 0.1) & (res_d_0 < 1)].any().any():    # there must be a more elegant check
+        y_limit = 0.1
+    else:
+        y_limit = v0d
     plot_logdiff_time(ax, res_d, f"days since {v0d} deaths",
                       "daily new deaths\n(rolling 7-day mean)",
-                      v0=0.1, highlight={res_d.columns[0]:"C0"},
+                      v0=y_limit, highlight={res_d.columns[0]:"C0"},
                       labeloffset=0.5)
 
     fig.tight_layout(pad=1)

--- a/coronavirus.py
+++ b/coronavirus.py
@@ -565,7 +565,7 @@ def make_compare_plot_germany(region_subregion,
     ax = axes[1]
     plot_logdiff_time(ax, res_d, f"days since {v0d} deaths",
                       "daily new deaths\n(rolling 7-day mean)",
-                      v0=v0d, highlight={res_d.columns[0]:"C0"},
+                      v0=0.1, highlight={res_d.columns[0]:"C0"},
                       labeloffset=0.5)
 
     fig.tight_layout(pad=1)


### PR DESCRIPTION
This fixes the #3. What it does is it checks whether there are values in the range (0.1, 1) in the data from day zero onward. If yes, then it sets the lower y-limit of the death toll graph to 0.1.

The result looks like this:
![image](https://user-images.githubusercontent.com/1487169/78794981-b79fd180-79b4-11ea-8c0a-671ff7b74ecf.png)
