### PR TITLE
Rolling average tolerates gaps (this fixes #10)

### DIFF
--- a/coronavirus.py
+++ b/coronavirus.py
@@ -308,7 +308,7 @@ def plot_doubling_time(ax, series, color, minchange=10):
     ax.plot(dtime.index, dtime.values, 'o', color=color, alpha=0.3, label=label)
 
     # need rolling average to smooth out weekly variations
-    rolling = dtime.rolling(7, center=True).mean()
+    rolling = dtime.rolling(7, min_periods=1, center=True).mean()
 
     # good to take maximum value from here
     ymax = min(rolling.max()*1.5, 500)


### PR DESCRIPTION
This fixes #10:

By default the [rolling](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.rolling.html) function works only with fully filled windows. But there is a parameter `min_periods` which makes it working with sparse arrays.

See the result:
 
![image](https://user-images.githubusercontent.com/1487169/79235149-879c7680-7e6b-11ea-8a34-f6e8b929d8a1.png)
