### PR TITLE
Fix for svg plot bug

### DIFF
--- a/coronavirus/coronavirus.py
+++ b/coronavirus/coronavirus.py
@@ -602,6 +602,7 @@ def plot_logdiff_time(ax, df, xaxislabel, yaxislabel, style="", labels=True, lab
             tmp = df[col].dropna()
             if len(tmp) > 0:   # possible we have no data points
                 x, y = tmp.index[-1], tmp.values[-1]
+                y = np.NaN if y == 0 else y
                 ax.annotate(col, xy=(x + labeloffset, y), textcoords='data')
                 ax.plot([x], [y], "o" + color, alpha=alpha)
     # ax.legend()


### PR DESCRIPTION
Looked at this a bit more and what seems to have been happening was that sometimes when no data was available a y value of 0 was being plotted.

This shouldn't really be a problem since `set_ylim` is called, so the value wouldn't be plotted. But for some reason even though the point wasn't visible the SVG backend tried to make the plot size large enough to fit... 0 on a log-y axis, so you got a 50,000pt long plot.

This simple change seems to fix the issue, but the problem really seems to be in the SVG backend, as the PNG one handles this properly.