### PR TITLE
Pelican remove categories

### DIFF
--- a/tools/generate-countries.ipynb
+++ b/tools/generate-countries.ipynb
@@ -443,16 +443,15 @@
     "    \"\"\"Create pelican markdown file, like this:\n",
     "    \n",
     "    title: Germany\n",
-    "    category: Data\n",
-    "    tags: data, plots\n",
+    "    tags: Data, Plots, Germany\n",
     "    save-as: germany\n",
     "    date: 2020-04-11 08:00\n",
     "    \"\"\"\n",
     "\n",
     "    with open(os.path.join(pelican_file_path), \"tw\") as f:\n",
     "        f.write(f\"title: {title}\\n\")\n",
-    "        f.write(f\"category: Data\\n\")\n",
-    "        f.write(f\"tags: data, plots\\n\")\n",
+    "        # f.write(f\"category: Data\\n\")  - have stopped using categories (22 April 2020)\n",
+    "        f.write(f\"tags: Data, Plots, {title}\\n\")\n",
     "        f.write(f\"save-as: {save_as}\\n\")\n",
     "        date_time = datetime.datetime.now().strftime(\"%Y/%m/%d %H:%M\")\n",
     "        f.write(f\"date: {date_time}\\n\")\n",
@@ -620,7 +619,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/tools/pelican/content/contribute.md
+++ b/tools/pelican/content/contribute.md
@@ -1,6 +1,6 @@
 Title: Contributions welcome!
 Date: 2020-04-10 22:00
-category: About
+tags: About
 slug: contribute
 
 * We gather some

--- a/tools/pelican/content/data-sources.md
+++ b/tools/pelican/content/data-sources.md
@@ -1,6 +1,6 @@
 Title: Data sources
 Date: 2020-04-10 22:03
-category: About
+tags: About
 slug: data-sources
 
 - We use data 

--- a/tools/pelican/content/faq.md
+++ b/tools/pelican/content/faq.md
@@ -1,8 +1,7 @@
 Title: Frequently Asked Questions (FAQ)
 Date: 2020-04-09 19:00
-category: About
 slug: faq
-tags: data
+tags: Data, About, FAQ
 
 
 # What about errors in the data?

--- a/tools/pelican/content/germany.md
+++ b/tools/pelican/content/germany.md
@@ -1,421 +1,420 @@
 title: Germany
-category: Data
-tags: data, plots
+tags: Data, Plots, Germany
 save-as: germany
-date: 2020/04/21 07:31
+date: 2020/04/22 12:11
 
 
 | Location                                                                                                                                    | Total cases   |   Total deaths |
 |:--------------------------------------------------------------------------------------------------------------------------------------------|:--------------|---------------:|
-| [Germany: Baden-Württemberg : LK Alb-Donau-Kreis](html/Germany-Baden-Württemberg-LK-Alb-Donau-Kreis.html)                                   | 470           |              8 |
-| [Germany: Baden-Württemberg : LK Biberach](html/Germany-Baden-Württemberg-LK-Biberach.html)                                                 | 478           |             16 |
+| [Germany: Baden-Württemberg : LK Alb-Donau-Kreis](html/Germany-Baden-Württemberg-LK-Alb-Donau-Kreis.html)                                   | 476           |              8 |
+| [Germany: Baden-Württemberg : LK Biberach](html/Germany-Baden-Württemberg-LK-Biberach.html)                                                 | 481           |             16 |
 | [Germany: Baden-Württemberg : LK Bodenseekreis](html/Germany-Baden-Württemberg-LK-Bodenseekreis.html)                                       | 270           |              7 |
-| [Germany: Baden-Württemberg : LK Breisgau-Hochschwarzwald](html/Germany-Baden-Württemberg-LK-Breisgau-Hochschwarzwald.html)                 | 978           |             36 |
-| [Germany: Baden-Württemberg : LK Böblingen](html/Germany-Baden-Württemberg-LK-Böblingen.html)                                               | 1,250         |             34 |
-| [Germany: Baden-Württemberg : LK Calw](html/Germany-Baden-Württemberg-LK-Calw.html)                                                         | 595           |             14 |
-| [Germany: Baden-Württemberg : LK Emmendingen](html/Germany-Baden-Württemberg-LK-Emmendingen.html)                                           | 509           |             33 |
-| [Germany: Baden-Württemberg : LK Enzkreis](html/Germany-Baden-Württemberg-LK-Enzkreis.html)                                                 | 410           |             11 |
-| [Germany: Baden-Württemberg : LK Esslingen](html/Germany-Baden-Württemberg-LK-Esslingen.html)                                               | 1,539         |             65 |
+| [Germany: Baden-Württemberg : LK Breisgau-Hochschwarzwald](html/Germany-Baden-Württemberg-LK-Breisgau-Hochschwarzwald.html)                 | 982           |             36 |
+| [Germany: Baden-Württemberg : LK Böblingen](html/Germany-Baden-Württemberg-LK-Böblingen.html)                                               | 1,255         |             35 |
+| [Germany: Baden-Württemberg : LK Calw](html/Germany-Baden-Württemberg-LK-Calw.html)                                                         | 606           |             14 |
+| [Germany: Baden-Württemberg : LK Emmendingen](html/Germany-Baden-Württemberg-LK-Emmendingen.html)                                           | 508           |             35 |
+| [Germany: Baden-Württemberg : LK Enzkreis](html/Germany-Baden-Württemberg-LK-Enzkreis.html)                                                 | 438           |             12 |
+| [Germany: Baden-Württemberg : LK Esslingen](html/Germany-Baden-Württemberg-LK-Esslingen.html)                                               | 1,534         |             62 |
 | [Germany: Baden-Württemberg : LK Freudenstadt](html/Germany-Baden-Württemberg-LK-Freudenstadt.html)                                         | 513           |             23 |
-| [Germany: Baden-Württemberg : LK Göppingen](html/Germany-Baden-Württemberg-LK-Göppingen.html)                                               | 713           |             31 |
-| [Germany: Baden-Württemberg : LK Heidenheim](html/Germany-Baden-Württemberg-LK-Heidenheim.html)                                             | 398           |             29 |
-| [Germany: Baden-Württemberg : LK Heilbronn](html/Germany-Baden-Württemberg-LK-Heilbronn.html)                                               | 782           |             22 |
-| [Germany: Baden-Württemberg : LK Hohenlohekreis](html/Germany-Baden-Württemberg-LK-Hohenlohekreis.html)                                     | 709           |             34 |
-| [Germany: Baden-Württemberg : LK Karlsruhe](html/Germany-Baden-Württemberg-LK-Karlsruhe.html)                                               | 817           |             42 |
+| [Germany: Baden-Württemberg : LK Göppingen](html/Germany-Baden-Württemberg-LK-Göppingen.html)                                               | 717           |             32 |
+| [Germany: Baden-Württemberg : LK Heidenheim](html/Germany-Baden-Württemberg-LK-Heidenheim.html)                                             | 403           |             30 |
+| [Germany: Baden-Württemberg : LK Heilbronn](html/Germany-Baden-Württemberg-LK-Heilbronn.html)                                               | 782           |             23 |
+| [Germany: Baden-Württemberg : LK Hohenlohekreis](html/Germany-Baden-Württemberg-LK-Hohenlohekreis.html)                                     | 710           |             35 |
+| [Germany: Baden-Württemberg : LK Karlsruhe](html/Germany-Baden-Württemberg-LK-Karlsruhe.html)                                               | 828           |             45 |
 | [Germany: Baden-Württemberg : LK Konstanz](html/Germany-Baden-Württemberg-LK-Konstanz.html)                                                 | 394           |              8 |
-| [Germany: Baden-Württemberg : LK Ludwigsburg](html/Germany-Baden-Württemberg-LK-Ludwigsburg.html)                                           | 1,445         |             43 |
-| [Germany: Baden-Württemberg : LK Lörrach](html/Germany-Baden-Württemberg-LK-Lörrach.html)                                                   | 503           |             31 |
-| [Germany: Baden-Württemberg : LK Main-Tauber-Kreis](html/Germany-Baden-Württemberg-LK-Main-Tauber-Kreis.html)                               | 320           |              7 |
-| [Germany: Baden-Württemberg : LK Neckar-Odenwald-Kreis](html/Germany-Baden-Württemberg-LK-Neckar-Odenwald-Kreis.html)                       | 289           |              9 |
-| [Germany: Baden-Württemberg : LK Ortenaukreis](html/Germany-Baden-Württemberg-LK-Ortenaukreis.html)                                         | 915           |             72 |
-| [Germany: Baden-Württemberg : LK Ostalbkreis](html/Germany-Baden-Württemberg-LK-Ostalbkreis.html)                                           | 994           |             14 |
+| [Germany: Baden-Württemberg : LK Ludwigsburg](html/Germany-Baden-Württemberg-LK-Ludwigsburg.html)                                           | 1,451         |             46 |
+| [Germany: Baden-Württemberg : LK Lörrach](html/Germany-Baden-Württemberg-LK-Lörrach.html)                                                   | 506           |             32 |
+| [Germany: Baden-Württemberg : LK Main-Tauber-Kreis](html/Germany-Baden-Württemberg-LK-Main-Tauber-Kreis.html)                               | 322           |              7 |
+| [Germany: Baden-Württemberg : LK Neckar-Odenwald-Kreis](html/Germany-Baden-Württemberg-LK-Neckar-Odenwald-Kreis.html)                       | 291           |             11 |
+| [Germany: Baden-Württemberg : LK Ortenaukreis](html/Germany-Baden-Württemberg-LK-Ortenaukreis.html)                                         | 915           |             75 |
+| [Germany: Baden-Württemberg : LK Ostalbkreis](html/Germany-Baden-Württemberg-LK-Ostalbkreis.html)                                           | 1,015         |             18 |
 | [Germany: Baden-Württemberg : LK Rastatt](html/Germany-Baden-Württemberg-LK-Rastatt.html)                                                   | 469           |             11 |
-| [Germany: Baden-Württemberg : LK Ravensburg](html/Germany-Baden-Württemberg-LK-Ravensburg.html)                                             | 501           |              6 |
+| [Germany: Baden-Württemberg : LK Ravensburg](html/Germany-Baden-Württemberg-LK-Ravensburg.html)                                             | 504           |              6 |
 | [Germany: Baden-Württemberg : LK Rems-Murr-Kreis](html/Germany-Baden-Württemberg-LK-Rems-Murr-Kreis.html)                                   | 1,084         |             38 |
-| [Germany: Baden-Württemberg : LK Reutlingen](html/Germany-Baden-Württemberg-LK-Reutlingen.html)                                             | 1,260         |             16 |
-| [Germany: Baden-Württemberg : LK Rhein-Neckar-Kreis](html/Germany-Baden-Württemberg-LK-Rhein-Neckar-Kreis.html)                             | 851           |             24 |
-| [Germany: Baden-Württemberg : LK Rottweil](html/Germany-Baden-Württemberg-LK-Rottweil.html)                                                 | 531           |             11 |
-| [Germany: Baden-Württemberg : LK Schwarzwald-Baar-Kreis](html/Germany-Baden-Württemberg-LK-Schwarzwald-Baar-Kreis.html)                     | 430           |             12 |
-| [Germany: Baden-Württemberg : LK Schwäbisch Hall](html/Germany-Baden-Württemberg-LK-Schwäbisch-Hall.html)                                   | 708           |             39 |
-| [Germany: Baden-Württemberg : LK Sigmaringen](html/Germany-Baden-Württemberg-LK-Sigmaringen.html)                                           | 703           |             29 |
-| [Germany: Baden-Württemberg : LK Tuttlingen](html/Germany-Baden-Württemberg-LK-Tuttlingen.html)                                             | 395           |             10 |
-| [Germany: Baden-Württemberg : LK Tübingen](html/Germany-Baden-Württemberg-LK-Tübingen.html)                                                 | 1,158         |             35 |
+| [Germany: Baden-Württemberg : LK Reutlingen](html/Germany-Baden-Württemberg-LK-Reutlingen.html)                                             | 1,265         |             16 |
+| [Germany: Baden-Württemberg : LK Rhein-Neckar-Kreis](html/Germany-Baden-Württemberg-LK-Rhein-Neckar-Kreis.html)                             | 846           |             25 |
+| [Germany: Baden-Württemberg : LK Rottweil](html/Germany-Baden-Württemberg-LK-Rottweil.html)                                                 | 539           |             11 |
+| [Germany: Baden-Württemberg : LK Schwarzwald-Baar-Kreis](html/Germany-Baden-Württemberg-LK-Schwarzwald-Baar-Kreis.html)                     | 436           |             13 |
+| [Germany: Baden-Württemberg : LK Schwäbisch Hall](html/Germany-Baden-Württemberg-LK-Schwäbisch-Hall.html)                                   | 720           |             40 |
+| [Germany: Baden-Württemberg : LK Sigmaringen](html/Germany-Baden-Württemberg-LK-Sigmaringen.html)                                           | 707           |             29 |
+| [Germany: Baden-Württemberg : LK Tuttlingen](html/Germany-Baden-Württemberg-LK-Tuttlingen.html)                                             | 401           |             10 |
+| [Germany: Baden-Württemberg : LK Tübingen](html/Germany-Baden-Württemberg-LK-Tübingen.html)                                                 | 1,169         |             35 |
 | [Germany: Baden-Württemberg : LK Waldshut](html/Germany-Baden-Württemberg-LK-Waldshut.html)                                                 | 279           |             26 |
-| [Germany: Baden-Württemberg : LK Zollernalbkreis](html/Germany-Baden-Württemberg-LK-Zollernalbkreis.html)                                   | 877           |             48 |
-| [Germany: Baden-Württemberg : SK Baden-Baden](html/Germany-Baden-Württemberg-SK-Baden-Baden.html)                                           | 162           |             13 |
-| [Germany: Baden-Württemberg : SK Freiburg i.Breisgau](html/Germany-Baden-Württemberg-SK-Freiburg-i.Breisgau.html)                           | 907           |             52 |
-| [Germany: Baden-Württemberg : SK Heidelberg](html/Germany-Baden-Württemberg-SK-Heidelberg.html)                                             | 262           |              6 |
-| [Germany: Baden-Württemberg : SK Heilbronn](html/Germany-Baden-Württemberg-SK-Heilbronn.html)                                               | 386           |             10 |
-| [Germany: Baden-Württemberg : SK Karlsruhe](html/Germany-Baden-Württemberg-SK-Karlsruhe.html)                                               | 315           |              4 |
-| [Germany: Baden-Württemberg : SK Mannheim](html/Germany-Baden-Württemberg-SK-Mannheim.html)                                                 | 418           |              6 |
-| [Germany: Baden-Württemberg : SK Pforzheim](html/Germany-Baden-Württemberg-SK-Pforzheim.html)                                               | 177           |              4 |
-| [Germany: Baden-Württemberg : SK Stuttgart](html/Germany-Baden-Württemberg-SK-Stuttgart.html)                                               | 1,239         |             39 |
-| [Germany: Baden-Württemberg : SK Ulm](html/Germany-Baden-Württemberg-SK-Ulm.html)                                                           | 225           |              3 |
+| [Germany: Baden-Württemberg : LK Zollernalbkreis](html/Germany-Baden-Württemberg-LK-Zollernalbkreis.html)                                   | 890           |             51 |
+| [Germany: Baden-Württemberg : SK Baden-Baden](html/Germany-Baden-Württemberg-SK-Baden-Baden.html)                                           | 163           |             13 |
+| [Germany: Baden-Württemberg : SK Freiburg i.Breisgau](html/Germany-Baden-Württemberg-SK-Freiburg-i.Breisgau.html)                           | 913           |             54 |
+| [Germany: Baden-Württemberg : SK Heidelberg](html/Germany-Baden-Württemberg-SK-Heidelberg.html)                                             | 264           |              6 |
+| [Germany: Baden-Württemberg : SK Heilbronn](html/Germany-Baden-Württemberg-SK-Heilbronn.html)                                               | 387           |             10 |
+| [Germany: Baden-Württemberg : SK Karlsruhe](html/Germany-Baden-Württemberg-SK-Karlsruhe.html)                                               | 317           |              4 |
+| [Germany: Baden-Württemberg : SK Mannheim](html/Germany-Baden-Württemberg-SK-Mannheim.html)                                                 | 421           |              6 |
+| [Germany: Baden-Württemberg : SK Pforzheim](html/Germany-Baden-Württemberg-SK-Pforzheim.html)                                               | 187           |              4 |
+| [Germany: Baden-Württemberg : SK Stuttgart](html/Germany-Baden-Württemberg-SK-Stuttgart.html)                                               | 1,246         |             39 |
+| [Germany: Baden-Württemberg : SK Ulm](html/Germany-Baden-Württemberg-SK-Ulm.html)                                                           | 228           |              3 |
 | [Germany: Bayern : LK Aichach-Friedberg](html/Germany-Bayern-LK-Aichach-Friedberg.html)                                                     | 260           |             17 |
-| [Germany: Bayern : LK Altötting](html/Germany-Bayern-LK-Altötting.html)                                                                     | 533           |             24 |
-| [Germany: Bayern : LK Amberg-Sulzbach](html/Germany-Bayern-LK-Amberg-Sulzbach.html)                                                         | 375           |             20 |
-| [Germany: Bayern : LK Ansbach](html/Germany-Bayern-LK-Ansbach.html)                                                                         | 445           |              7 |
-| [Germany: Bayern : LK Aschaffenburg](html/Germany-Bayern-LK-Aschaffenburg.html)                                                             | 440           |             22 |
-| [Germany: Bayern : LK Augsburg](html/Germany-Bayern-LK-Augsburg.html)                                                                       | 342           |              6 |
-| [Germany: Bayern : LK Bad Kissingen](html/Germany-Bayern-LK-Bad-Kissingen.html)                                                             | 210           |             10 |
+| [Germany: Bayern : LK Altötting](html/Germany-Bayern-LK-Altötting.html)                                                                     | 538           |             25 |
+| [Germany: Bayern : LK Amberg-Sulzbach](html/Germany-Bayern-LK-Amberg-Sulzbach.html)                                                         | 407           |             30 |
+| [Germany: Bayern : LK Ansbach](html/Germany-Bayern-LK-Ansbach.html)                                                                         | 449           |             10 |
+| [Germany: Bayern : LK Aschaffenburg](html/Germany-Bayern-LK-Aschaffenburg.html)                                                             | 446           |             22 |
+| [Germany: Bayern : LK Augsburg](html/Germany-Bayern-LK-Augsburg.html)                                                                       | 344           |              6 |
+| [Germany: Bayern : LK Bad Kissingen](html/Germany-Bayern-LK-Bad-Kissingen.html)                                                             | 211           |             10 |
 | [Germany: Bayern : LK Bad Tölz-Wolfratshausen](html/Germany-Bayern-LK-Bad-Tölz-Wolfratshausen.html)                                         | 385           |              7 |
-| [Germany: Bayern : LK Bamberg](html/Germany-Bayern-LK-Bamberg.html)                                                                         | 363           |             28 |
-| [Germany: Bayern : LK Bayreuth](html/Germany-Bayern-LK-Bayreuth.html)                                                                       | 353           |              7 |
-| [Germany: Bayern : LK Berchtesgadener Land](html/Germany-Bayern-LK-Berchtesgadener-Land.html)                                               | 248           |              9 |
+| [Germany: Bayern : LK Bamberg](html/Germany-Bayern-LK-Bamberg.html)                                                                         | 366           |             29 |
+| [Germany: Bayern : LK Bayreuth](html/Germany-Bayern-LK-Bayreuth.html)                                                                       | 354           |              7 |
+| [Germany: Bayern : LK Berchtesgadener Land](html/Germany-Bayern-LK-Berchtesgadener-Land.html)                                               | 252           |              9 |
 | [Germany: Bayern : LK Cham](html/Germany-Bayern-LK-Cham.html)                                                                               | 370           |             14 |
-| [Germany: Bayern : LK Coburg](html/Germany-Bayern-LK-Coburg.html)                                                                           | 154           |              4 |
+| [Germany: Bayern : LK Coburg](html/Germany-Bayern-LK-Coburg.html)                                                                           | 159           |              6 |
 | [Germany: Bayern : LK Dachau](html/Germany-Bayern-LK-Dachau.html)                                                                           | 740           |             14 |
-| [Germany: Bayern : LK Deggendorf](html/Germany-Bayern-LK-Deggendorf.html)                                                                   | 228           |              7 |
-| [Germany: Bayern : LK Dillingen a.d.Donau](html/Germany-Bayern-LK-Dillingen-a.d.Donau.html)                                                 | 199           |              4 |
-| [Germany: Bayern : LK Dingolfing-Landau](html/Germany-Bayern-LK-Dingolfing-Landau.html)                                                     | 176           |              3 |
+| [Germany: Bayern : LK Deggendorf](html/Germany-Bayern-LK-Deggendorf.html)                                                                   | 229           |              8 |
+| [Germany: Bayern : LK Dillingen a.d.Donau](html/Germany-Bayern-LK-Dillingen-a.d.Donau.html)                                                 | 202           |              4 |
+| [Germany: Bayern : LK Dingolfing-Landau](html/Germany-Bayern-LK-Dingolfing-Landau.html)                                                     | 178           |              3 |
 | [Germany: Bayern : LK Donau-Ries](html/Germany-Bayern-LK-Donau-Ries.html)                                                                   | 291           |             19 |
-| [Germany: Bayern : LK Ebersberg](html/Germany-Bayern-LK-Ebersberg.html)                                                                     | 394           |              2 |
-| [Germany: Bayern : LK Eichstätt](html/Germany-Bayern-LK-Eichstätt.html)                                                                     | 232           |             10 |
-| [Germany: Bayern : LK Erding](html/Germany-Bayern-LK-Erding.html)                                                                           | 524           |              7 |
-| [Germany: Bayern : LK Erlangen-Höchstadt](html/Germany-Bayern-LK-Erlangen-Höchstadt.html)                                                   | 189           |              6 |
+| [Germany: Bayern : LK Ebersberg](html/Germany-Bayern-LK-Ebersberg.html)                                                                     | 400           |              4 |
+| [Germany: Bayern : LK Eichstätt](html/Germany-Bayern-LK-Eichstätt.html)                                                                     | 239           |             11 |
+| [Germany: Bayern : LK Erding](html/Germany-Bayern-LK-Erding.html)                                                                           | 528           |              8 |
+| [Germany: Bayern : LK Erlangen-Höchstadt](html/Germany-Bayern-LK-Erlangen-Höchstadt.html)                                                   | 190           |              6 |
 | [Germany: Bayern : LK Forchheim](html/Germany-Bayern-LK-Forchheim.html)                                                                     | 195           |              3 |
-| [Germany: Bayern : LK Freising](html/Germany-Bayern-LK-Freising.html)                                                                       | 895           |             32 |
-| [Germany: Bayern : LK Freyung-Grafenau](html/Germany-Bayern-LK-Freyung-Grafenau.html)                                                       | 157           |              9 |
-| [Germany: Bayern : LK Fürstenfeldbruck](html/Germany-Bayern-LK-Fürstenfeldbruck.html)                                                       | 712           |             26 |
-| [Germany: Bayern : LK Fürth](html/Germany-Bayern-LK-Fürth.html)                                                                             | 411           |             37 |
-| [Germany: Bayern : LK Garmisch-Partenkirchen](html/Germany-Bayern-LK-Garmisch-Partenkirchen.html)                                           | 239           |              9 |
-| [Germany: Bayern : LK Günzburg](html/Germany-Bayern-LK-Günzburg.html)                                                                       | 209           |              2 |
-| [Germany: Bayern : LK Haßberge](html/Germany-Bayern-LK-Haßberge.html)                                                                       | 135           |              2 |
-| [Germany: Bayern : LK Hof](html/Germany-Bayern-LK-Hof.html)                                                                                 | 330           |             18 |
-| [Germany: Bayern : LK Kelheim](html/Germany-Bayern-LK-Kelheim.html)                                                                         | 398           |             26 |
-| [Germany: Bayern : LK Kitzingen](html/Germany-Bayern-LK-Kitzingen.html)                                                                     | 92            |              1 |
-| [Germany: Bayern : LK Kronach](html/Germany-Bayern-LK-Kronach.html)                                                                         | 106           |              1 |
-| [Germany: Bayern : LK Kulmbach](html/Germany-Bayern-LK-Kulmbach.html)                                                                       | 174           |              7 |
-| [Germany: Bayern : LK Landsberg a.Lech](html/Germany-Bayern-LK-Landsberg-a.Lech.html)                                                       | 302           |              9 |
-| [Germany: Bayern : LK Landshut](html/Germany-Bayern-LK-Landshut.html)                                                                       | 607           |             22 |
-| [Germany: Bayern : LK Lichtenfels](html/Germany-Bayern-LK-Lichtenfels.html)                                                                 | 174           |              1 |
-| [Germany: Bayern : LK Lindau](html/Germany-Bayern-LK-Lindau.html)                                                                           | 235           |              5 |
-| [Germany: Bayern : LK Main-Spessart](html/Germany-Bayern-LK-Main-Spessart.html)                                                             | 147           |              5 |
+| [Germany: Bayern : LK Freising](html/Germany-Bayern-LK-Freising.html)                                                                       | 901           |             32 |
+| [Germany: Bayern : LK Freyung-Grafenau](html/Germany-Bayern-LK-Freyung-Grafenau.html)                                                       | 159           |              9 |
+| [Germany: Bayern : LK Fürstenfeldbruck](html/Germany-Bayern-LK-Fürstenfeldbruck.html)                                                       | 721           |             26 |
+| [Germany: Bayern : LK Fürth](html/Germany-Bayern-LK-Fürth.html)                                                                             | 428           |             44 |
+| [Germany: Bayern : LK Garmisch-Partenkirchen](html/Germany-Bayern-LK-Garmisch-Partenkirchen.html)                                           | 241           |             11 |
+| [Germany: Bayern : LK Günzburg](html/Germany-Bayern-LK-Günzburg.html)                                                                       | 210           |              2 |
+| [Germany: Bayern : LK Haßberge](html/Germany-Bayern-LK-Haßberge.html)                                                                       | 136           |              2 |
+| [Germany: Bayern : LK Hof](html/Germany-Bayern-LK-Hof.html)                                                                                 | 335           |             18 |
+| [Germany: Bayern : LK Kelheim](html/Germany-Bayern-LK-Kelheim.html)                                                                         | 398           |             28 |
+| [Germany: Bayern : LK Kitzingen](html/Germany-Bayern-LK-Kitzingen.html)                                                                     | 100           |              1 |
+| [Germany: Bayern : LK Kronach](html/Germany-Bayern-LK-Kronach.html)                                                                         | 108           |              1 |
+| [Germany: Bayern : LK Kulmbach](html/Germany-Bayern-LK-Kulmbach.html)                                                                       | 177           |              9 |
+| [Germany: Bayern : LK Landsberg a.Lech](html/Germany-Bayern-LK-Landsberg-a.Lech.html)                                                       | 305           |              9 |
+| [Germany: Bayern : LK Landshut](html/Germany-Bayern-LK-Landshut.html)                                                                       | 606           |             22 |
+| [Germany: Bayern : LK Lichtenfels](html/Germany-Bayern-LK-Lichtenfels.html)                                                                 | 184           |              1 |
+| [Germany: Bayern : LK Lindau](html/Germany-Bayern-LK-Lindau.html)                                                                           | 236           |              5 |
+| [Germany: Bayern : LK Main-Spessart](html/Germany-Bayern-LK-Main-Spessart.html)                                                             | 139           |              5 |
 | [Germany: Bayern : LK Miesbach](html/Germany-Bayern-LK-Miesbach.html)                                                                       | 482           |              7 |
-| [Germany: Bayern : LK Miltenberg](html/Germany-Bayern-LK-Miltenberg.html)                                                                   | 244           |              3 |
-| [Germany: Bayern : LK Mühldorf a.Inn](html/Germany-Bayern-LK-Mühldorf-a.Inn.html)                                                           | 433           |             17 |
+| [Germany: Bayern : LK Miltenberg](html/Germany-Bayern-LK-Miltenberg.html)                                                                   | 245           |              3 |
+| [Germany: Bayern : LK Mühldorf a.Inn](html/Germany-Bayern-LK-Mühldorf-a.Inn.html)                                                           | 436           |             17 |
 | [Germany: Bayern : LK München](html/Germany-Bayern-LK-München.html)                                                                         | 1,135         |             20 |
-| [Germany: Bayern : LK Neu-Ulm](html/Germany-Bayern-LK-Neu-Ulm.html)                                                                         | 392           |             14 |
-| [Germany: Bayern : LK Neuburg-Schrobenhausen](html/Germany-Bayern-LK-Neuburg-Schrobenhausen.html)                                           | 221           |              9 |
-| [Germany: Bayern : LK Neumarkt i.d.OPf.](html/Germany-Bayern-LK-Neumarkt-i.d.OPf..html)                                                     | 284           |              7 |
+| [Germany: Bayern : LK Neu-Ulm](html/Germany-Bayern-LK-Neu-Ulm.html)                                                                         | 394           |             14 |
+| [Germany: Bayern : LK Neuburg-Schrobenhausen](html/Germany-Bayern-LK-Neuburg-Schrobenhausen.html)                                           | 223           |              9 |
+| [Germany: Bayern : LK Neumarkt i.d.OPf.](html/Germany-Bayern-LK-Neumarkt-i.d.OPf..html)                                                     | 292           |              7 |
 | [Germany: Bayern : LK Neustadt a.d.Aisch-Bad Windsheim](html/Germany-Bayern-LK-Neustadt-a.d.Aisch-Bad-Windsheim.html)                       | 205           |              6 |
-| [Germany: Bayern : LK Neustadt a.d.Waldnaab](html/Germany-Bayern-LK-Neustadt-a.d.Waldnaab.html)                                             | 668           |             30 |
-| [Germany: Bayern : LK Nürnberger Land](html/Germany-Bayern-LK-Nürnberger-Land.html)                                                         | 541           |             26 |
+| [Germany: Bayern : LK Neustadt a.d.Waldnaab](html/Germany-Bayern-LK-Neustadt-a.d.Waldnaab.html)                                             | 669           |             33 |
+| [Germany: Bayern : LK Nürnberger Land](html/Germany-Bayern-LK-Nürnberger-Land.html)                                                         | 555           |             28 |
 | [Germany: Bayern : LK Oberallgäu](html/Germany-Bayern-LK-Oberallgäu.html)                                                                   | 163           |              6 |
-| [Germany: Bayern : LK Ostallgäu](html/Germany-Bayern-LK-Ostallgäu.html)                                                                     | 466           |             21 |
-| [Germany: Bayern : LK Passau](html/Germany-Bayern-LK-Passau.html)                                                                           | 398           |             16 |
-| [Germany: Bayern : LK Pfaffenhofen a.d.Ilm](html/Germany-Bayern-LK-Pfaffenhofen-a.d.Ilm.html)                                               | 304           |             15 |
-| [Germany: Bayern : LK Regen](html/Germany-Bayern-LK-Regen.html)                                                                             | 143           |              2 |
+| [Germany: Bayern : LK Ostallgäu](html/Germany-Bayern-LK-Ostallgäu.html)                                                                     | 467           |             25 |
+| [Germany: Bayern : LK Passau](html/Germany-Bayern-LK-Passau.html)                                                                           | 402           |             16 |
+| [Germany: Bayern : LK Pfaffenhofen a.d.Ilm](html/Germany-Bayern-LK-Pfaffenhofen-a.d.Ilm.html)                                               | 310           |             16 |
+| [Germany: Bayern : LK Regen](html/Germany-Bayern-LK-Regen.html)                                                                             | 144           |              2 |
 | [Germany: Bayern : LK Regensburg](html/Germany-Bayern-LK-Regensburg.html)                                                                   | 378           |              3 |
-| [Germany: Bayern : LK Rhön-Grabfeld](html/Germany-Bayern-LK-Rhön-Grabfeld.html)                                                             | 140           |              4 |
-| [Germany: Bayern : LK Rosenheim](html/Germany-Bayern-LK-Rosenheim.html)                                                                     | 1,797         |             90 |
-| [Germany: Bayern : LK Roth](html/Germany-Bayern-LK-Roth.html)                                                                               | 270           |              7 |
-| [Germany: Bayern : LK Rottal-Inn](html/Germany-Bayern-LK-Rottal-Inn.html)                                                                   | 677           |             37 |
-| [Germany: Bayern : LK Schwandorf](html/Germany-Bayern-LK-Schwandorf.html)                                                                   | 412           |             12 |
-| [Germany: Bayern : LK Schweinfurt](html/Germany-Bayern-LK-Schweinfurt.html)                                                                 | 391           |             16 |
-| [Germany: Bayern : LK Starnberg](html/Germany-Bayern-LK-Starnberg.html)                                                                     | 481           |              8 |
-| [Germany: Bayern : LK Straubing-Bogen](html/Germany-Bayern-LK-Straubing-Bogen.html)                                                         | 355           |             13 |
+| [Germany: Bayern : LK Rhön-Grabfeld](html/Germany-Bayern-LK-Rhön-Grabfeld.html)                                                             | 145           |              4 |
+| [Germany: Bayern : LK Rosenheim](html/Germany-Bayern-LK-Rosenheim.html)                                                                     | 1,841         |             97 |
+| [Germany: Bayern : LK Roth](html/Germany-Bayern-LK-Roth.html)                                                                               | 273           |              7 |
+| [Germany: Bayern : LK Rottal-Inn](html/Germany-Bayern-LK-Rottal-Inn.html)                                                                   | 680           |             39 |
+| [Germany: Bayern : LK Schwandorf](html/Germany-Bayern-LK-Schwandorf.html)                                                                   | 415           |             14 |
+| [Germany: Bayern : LK Schweinfurt](html/Germany-Bayern-LK-Schweinfurt.html)                                                                 | 395           |             17 |
+| [Germany: Bayern : LK Starnberg](html/Germany-Bayern-LK-Starnberg.html)                                                                     | 484           |              9 |
+| [Germany: Bayern : LK Straubing-Bogen](html/Germany-Bayern-LK-Straubing-Bogen.html)                                                         | 356           |             14 |
 | [Germany: Bayern : LK Tirschenreuth](html/Germany-Bayern-LK-Tirschenreuth.html)                                                             | 1,069         |             93 |
-| [Germany: Bayern : LK Traunstein](html/Germany-Bayern-LK-Traunstein.html)                                                                   | 928           |             31 |
-| [Germany: Bayern : LK Unterallgäu](html/Germany-Bayern-LK-Unterallgäu.html)                                                                 | 228           |              4 |
-| [Germany: Bayern : LK Weilheim-Schongau](html/Germany-Bayern-LK-Weilheim-Schongau.html)                                                     | 332           |              1 |
-| [Germany: Bayern : LK Weißenburg-Gunzenhausen](html/Germany-Bayern-LK-Weißenburg-Gunzenhausen.html)                                         | 262           |              9 |
-| [Germany: Bayern : LK Wunsiedel i.Fichtelgebirge](html/Germany-Bayern-LK-Wunsiedel-i.Fichtelgebirge.html)                                   | 572           |             32 |
-| [Germany: Bayern : LK Würzburg](html/Germany-Bayern-LK-Würzburg.html)                                                                       | 386           |              5 |
-| [Germany: Bayern : SK Amberg](html/Germany-Bayern-SK-Amberg.html)                                                                           | 60            |              3 |
-| [Germany: Bayern : SK Ansbach](html/Germany-Bayern-SK-Ansbach.html)                                                                         | 85            |              5 |
+| [Germany: Bayern : LK Traunstein](html/Germany-Bayern-LK-Traunstein.html)                                                                   | 955           |             46 |
+| [Germany: Bayern : LK Unterallgäu](html/Germany-Bayern-LK-Unterallgäu.html)                                                                 | 229           |              4 |
+| [Germany: Bayern : LK Weilheim-Schongau](html/Germany-Bayern-LK-Weilheim-Schongau.html)                                                     | 334           |              1 |
+| [Germany: Bayern : LK Weißenburg-Gunzenhausen](html/Germany-Bayern-LK-Weißenburg-Gunzenhausen.html)                                         | 266           |             11 |
+| [Germany: Bayern : LK Wunsiedel i.Fichtelgebirge](html/Germany-Bayern-LK-Wunsiedel-i.Fichtelgebirge.html)                                   | 575           |             32 |
+| [Germany: Bayern : LK Würzburg](html/Germany-Bayern-LK-Würzburg.html)                                                                       | 392           |              5 |
+| [Germany: Bayern : SK Amberg](html/Germany-Bayern-SK-Amberg.html)                                                                           | 65            |              3 |
+| [Germany: Bayern : SK Ansbach](html/Germany-Bayern-SK-Ansbach.html)                                                                         | 88            |              5 |
 | [Germany: Bayern : SK Aschaffenburg](html/Germany-Bayern-SK-Aschaffenburg.html)                                                             | 99            |              1 |
-| [Germany: Bayern : SK Augsburg](html/Germany-Bayern-SK-Augsburg.html)                                                                       | 339           |              9 |
-| [Germany: Bayern : SK Bamberg](html/Germany-Bayern-SK-Bamberg.html)                                                                         | 169           |             12 |
+| [Germany: Bayern : SK Augsburg](html/Germany-Bayern-SK-Augsburg.html)                                                                       | 341           |              9 |
+| [Germany: Bayern : SK Bamberg](html/Germany-Bayern-SK-Bamberg.html)                                                                         | 171           |             12 |
 | [Germany: Bayern : SK Bayreuth](html/Germany-Bayern-SK-Bayreuth.html)                                                                       | 165           |              4 |
-| [Germany: Bayern : SK Coburg](html/Germany-Bayern-SK-Coburg.html)                                                                           | 48            |              0 |
-| [Germany: Bayern : SK Erlangen](html/Germany-Bayern-SK-Erlangen.html)                                                                       | 212           |              4 |
-| [Germany: Bayern : SK Fürth](html/Germany-Bayern-SK-Fürth.html)                                                                             | 270           |             20 |
+| [Germany: Bayern : SK Coburg](html/Germany-Bayern-SK-Coburg.html)                                                                           | 49            |              0 |
+| [Germany: Bayern : SK Erlangen](html/Germany-Bayern-SK-Erlangen.html)                                                                       | 213           |              4 |
+| [Germany: Bayern : SK Fürth](html/Germany-Bayern-SK-Fürth.html)                                                                             | 288           |             20 |
 | [Germany: Bayern : SK Hof](html/Germany-Bayern-SK-Hof.html)                                                                                 | 94            |              2 |
-| [Germany: Bayern : SK Ingolstadt](html/Germany-Bayern-SK-Ingolstadt.html)                                                                   | 350           |             19 |
-| [Germany: Bayern : SK Kaufbeuren](html/Germany-Bayern-SK-Kaufbeuren.html)                                                                   | 91            |              3 |
-| [Germany: Bayern : SK Kempten](html/Germany-Bayern-SK-Kempten.html)                                                                         | 97            |              7 |
-| [Germany: Bayern : SK Landshut](html/Germany-Bayern-SK-Landshut.html)                                                                       | 252           |              5 |
-| [Germany: Bayern : SK Memmingen](html/Germany-Bayern-SK-Memmingen.html)                                                                     | 47            |              0 |
-| [Germany: Bayern : SK München](html/Germany-Bayern-SK-München.html)                                                                         | 5,130         |             75 |
-| [Germany: Bayern : SK Nürnberg](html/Germany-Bayern-SK-Nürnberg.html)                                                                       | 796           |             17 |
+| [Germany: Bayern : SK Ingolstadt](html/Germany-Bayern-SK-Ingolstadt.html)                                                                   | 362           |             19 |
+| [Germany: Bayern : SK Kaufbeuren](html/Germany-Bayern-SK-Kaufbeuren.html)                                                                   | 89            |              3 |
+| [Germany: Bayern : SK Kempten](html/Germany-Bayern-SK-Kempten.html)                                                                         | 100           |              7 |
+| [Germany: Bayern : SK Landshut](html/Germany-Bayern-SK-Landshut.html)                                                                       | 253           |              5 |
+| [Germany: Bayern : SK Memmingen](html/Germany-Bayern-SK-Memmingen.html)                                                                     | 48            |              0 |
+| [Germany: Bayern : SK München](html/Germany-Bayern-SK-München.html)                                                                         | 5,176         |             78 |
+| [Germany: Bayern : SK Nürnberg](html/Germany-Bayern-SK-Nürnberg.html)                                                                       | 813           |             17 |
 | [Germany: Bayern : SK Passau](html/Germany-Bayern-SK-Passau.html)                                                                           | 116           |             15 |
-| [Germany: Bayern : SK Regensburg](html/Germany-Bayern-SK-Regensburg.html)                                                                   | 372           |              3 |
-| [Germany: Bayern : SK Rosenheim](html/Germany-Bayern-SK-Rosenheim.html)                                                                     | 348           |             13 |
+| [Germany: Bayern : SK Regensburg](html/Germany-Bayern-SK-Regensburg.html)                                                                   | 377           |              3 |
+| [Germany: Bayern : SK Rosenheim](html/Germany-Bayern-SK-Rosenheim.html)                                                                     | 356           |             14 |
 | [Germany: Bayern : SK Schwabach](html/Germany-Bayern-SK-Schwabach.html)                                                                     | 72            |              1 |
-| [Germany: Bayern : SK Schweinfurt](html/Germany-Bayern-SK-Schweinfurt.html)                                                                 | 138           |             16 |
-| [Germany: Bayern : SK Straubing](html/Germany-Bayern-SK-Straubing.html)                                                                     | 298           |             23 |
-| [Germany: Bayern : SK Weiden i.d.OPf.](html/Germany-Bayern-SK-Weiden-i.d.OPf..html)                                                         | 252           |              5 |
-| [Germany: Bayern : SK Würzburg](html/Germany-Bayern-SK-Würzburg.html)                                                                       | 447           |             45 |
-| [Germany: Berlin : SK Berlin Charlottenburg-Wilmersdorf](html/Germany-Berlin-SK-Berlin-Charlottenburg-Wilmersdorf.html)                     | 614           |             15 |
-| [Germany: Berlin : SK Berlin Friedrichshain-Kreuzberg](html/Germany-Berlin-SK-Berlin-Friedrichshain-Kreuzberg.html)                         | 424           |              4 |
-| [Germany: Berlin : SK Berlin Lichtenberg](html/Germany-Berlin-SK-Berlin-Lichtenberg.html)                                                   | 196           |              5 |
-| [Germany: Berlin : SK Berlin Marzahn-Hellersdorf](html/Germany-Berlin-SK-Berlin-Marzahn-Hellersdorf.html)                                   | 216           |              1 |
-| [Germany: Berlin : SK Berlin Mitte](html/Germany-Berlin-SK-Berlin-Mitte.html)                                                               | 798           |              6 |
-| [Germany: Berlin : SK Berlin Neukölln](html/Germany-Berlin-SK-Berlin-Neukölln.html)                                                         | 541           |             15 |
-| [Germany: Berlin : SK Berlin Pankow](html/Germany-Berlin-SK-Berlin-Pankow.html)                                                             | 538           |              6 |
-| [Germany: Berlin : SK Berlin Reinickendorf](html/Germany-Berlin-SK-Berlin-Reinickendorf.html)                                               | 413           |             19 |
-| [Germany: Berlin : SK Berlin Spandau](html/Germany-Berlin-SK-Berlin-Spandau.html)                                                           | 215           |              6 |
-| [Germany: Berlin : SK Berlin Steglitz-Zehlendorf](html/Germany-Berlin-SK-Berlin-Steglitz-Zehlendorf.html)                                   | 440           |              4 |
-| [Germany: Berlin : SK Berlin Tempelhof-Schöneberg](html/Germany-Berlin-SK-Berlin-Tempelhof-Schöneberg.html)                                 | 530           |             13 |
-| [Germany: Berlin : SK Berlin Treptow-Köpenick](html/Germany-Berlin-SK-Berlin-Treptow-Köpenick.html)                                         | 267           |              3 |
-| [Germany: Brandenburg : LK Barnim](html/Germany-Brandenburg-LK-Barnim.html)                                                                 | 291           |             11 |
+| [Germany: Bayern : SK Schweinfurt](html/Germany-Bayern-SK-Schweinfurt.html)                                                                 | 139           |             16 |
+| [Germany: Bayern : SK Straubing](html/Germany-Bayern-SK-Straubing.html)                                                                     | 303           |             25 |
+| [Germany: Bayern : SK Weiden i.d.OPf.](html/Germany-Bayern-SK-Weiden-i.d.OPf..html)                                                         | 254           |              6 |
+| [Germany: Bayern : SK Würzburg](html/Germany-Bayern-SK-Würzburg.html)                                                                       | 449           |             48 |
+| [Germany: Berlin : SK Berlin Charlottenburg-Wilmersdorf](html/Germany-Berlin-SK-Berlin-Charlottenburg-Wilmersdorf.html)                     | 617           |             15 |
+| [Germany: Berlin : SK Berlin Friedrichshain-Kreuzberg](html/Germany-Berlin-SK-Berlin-Friedrichshain-Kreuzberg.html)                         | 425           |              4 |
+| [Germany: Berlin : SK Berlin Lichtenberg](html/Germany-Berlin-SK-Berlin-Lichtenberg.html)                                                   | 198           |              5 |
+| [Germany: Berlin : SK Berlin Marzahn-Hellersdorf](html/Germany-Berlin-SK-Berlin-Marzahn-Hellersdorf.html)                                   | 222           |              1 |
+| [Germany: Berlin : SK Berlin Mitte](html/Germany-Berlin-SK-Berlin-Mitte.html)                                                               | 804           |              7 |
+| [Germany: Berlin : SK Berlin Neukölln](html/Germany-Berlin-SK-Berlin-Neukölln.html)                                                         | 556           |             15 |
+| [Germany: Berlin : SK Berlin Pankow](html/Germany-Berlin-SK-Berlin-Pankow.html)                                                             | 544           |             10 |
+| [Germany: Berlin : SK Berlin Reinickendorf](html/Germany-Berlin-SK-Berlin-Reinickendorf.html)                                               | 420           |             19 |
+| [Germany: Berlin : SK Berlin Spandau](html/Germany-Berlin-SK-Berlin-Spandau.html)                                                           | 218           |              6 |
+| [Germany: Berlin : SK Berlin Steglitz-Zehlendorf](html/Germany-Berlin-SK-Berlin-Steglitz-Zehlendorf.html)                                   | 440           |              5 |
+| [Germany: Berlin : SK Berlin Tempelhof-Schöneberg](html/Germany-Berlin-SK-Berlin-Tempelhof-Schöneberg.html)                                 | 539           |             14 |
+| [Germany: Berlin : SK Berlin Treptow-Köpenick](html/Germany-Berlin-SK-Berlin-Treptow-Köpenick.html)                                         | 269           |              4 |
+| [Germany: Brandenburg : LK Barnim](html/Germany-Brandenburg-LK-Barnim.html)                                                                 | 301           |             11 |
 | [Germany: Brandenburg : LK Dahme-Spreewald](html/Germany-Brandenburg-LK-Dahme-Spreewald.html)                                               | 160           |              4 |
 | [Germany: Brandenburg : LK Elbe-Elster](html/Germany-Brandenburg-LK-Elbe-Elster.html)                                                       | 72            |              2 |
-| [Germany: Brandenburg : LK Havelland](html/Germany-Brandenburg-LK-Havelland.html)                                                           | 142           |              5 |
-| [Germany: Brandenburg : LK Märkisch-Oderland](html/Germany-Brandenburg-LK-Märkisch-Oderland.html)                                           | 178           |              1 |
-| [Germany: Brandenburg : LK Oberhavel](html/Germany-Brandenburg-LK-Oberhavel.html)                                                           | 176           |              4 |
+| [Germany: Brandenburg : LK Havelland](html/Germany-Brandenburg-LK-Havelland.html)                                                           | 144           |              5 |
+| [Germany: Brandenburg : LK Märkisch-Oderland](html/Germany-Brandenburg-LK-Märkisch-Oderland.html)                                           | 182           |              1 |
+| [Germany: Brandenburg : LK Oberhavel](html/Germany-Brandenburg-LK-Oberhavel.html)                                                           | 199           |              5 |
 | [Germany: Brandenburg : LK Oberspreewald-Lausitz](html/Germany-Brandenburg-LK-Oberspreewald-Lausitz.html)                                   | 39            |              2 |
 | [Germany: Brandenburg : LK Oder-Spree](html/Germany-Brandenburg-LK-Oder-Spree.html)                                                         | 100           |              0 |
 | [Germany: Brandenburg : LK Ostprignitz-Ruppin](html/Germany-Brandenburg-LK-Ostprignitz-Ruppin.html)                                         | 37            |              0 |
-| [Germany: Brandenburg : LK Potsdam-Mittelmark](html/Germany-Brandenburg-LK-Potsdam-Mittelmark.html)                                         | 245           |              8 |
+| [Germany: Brandenburg : LK Potsdam-Mittelmark](html/Germany-Brandenburg-LK-Potsdam-Mittelmark.html)                                         | 279           |              8 |
 | [Germany: Brandenburg : LK Prignitz](html/Germany-Brandenburg-LK-Prignitz.html)                                                             | 22            |              0 |
 | [Germany: Brandenburg : LK Spree-Neiße](html/Germany-Brandenburg-LK-Spree-Neiße.html)                                                       | 55            |              0 |
-| [Germany: Brandenburg : LK Teltow-Fläming](html/Germany-Brandenburg-LK-Teltow-Fläming.html)                                                 | 103           |              4 |
+| [Germany: Brandenburg : LK Teltow-Fläming](html/Germany-Brandenburg-LK-Teltow-Fläming.html)                                                 | 110           |              5 |
 | [Germany: Brandenburg : LK Uckermark](html/Germany-Brandenburg-LK-Uckermark.html)                                                           | 28            |              1 |
-| [Germany: Brandenburg : SK Brandenburg a.d.Havel](html/Germany-Brandenburg-SK-Brandenburg-a.d.Havel.html)                                   | 48            |              0 |
+| [Germany: Brandenburg : SK Brandenburg a.d.Havel](html/Germany-Brandenburg-SK-Brandenburg-a.d.Havel.html)                                   | 49            |              0 |
 | [Germany: Brandenburg : SK Cottbus](html/Germany-Brandenburg-SK-Cottbus.html)                                                               | 39            |              0 |
 | [Germany: Brandenburg : SK Frankfurt (Oder)](html/Germany-Brandenburg-SK-Frankfurt-(Oder).html)                                             | 23            |              0 |
-| [Germany: Brandenburg : SK Potsdam](html/Germany-Brandenburg-SK-Potsdam.html)                                                               | 517           |             25 |
-| [Germany: Bremen : SK Bremen](html/Germany-Bremen-SK-Bremen.html)                                                                           | 575           |             24 |
-| [Germany: Bremen : SK Bremerhaven](html/Germany-Bremen-SK-Bremerhaven.html)                                                                 | 27            |              0 |
-| [Germany: Hamburg : SK Hamburg](html/Germany-Hamburg-SK-Hamburg.html)                                                                       | 4,203         |             91 |
-| [Germany: Hessen : LK Bergstraße](html/Germany-Hessen-LK-Bergstraße.html)                                                                   | 286           |              2 |
-| [Germany: Hessen : LK Darmstadt-Dieburg](html/Germany-Hessen-LK-Darmstadt-Dieburg.html)                                                     | 334           |             11 |
-| [Germany: Hessen : LK Fulda](html/Germany-Hessen-LK-Fulda.html)                                                                             | 289           |              8 |
+| [Germany: Brandenburg : SK Potsdam](html/Germany-Brandenburg-SK-Potsdam.html)                                                               | 529           |             29 |
+| [Germany: Bremen : SK Bremen](html/Germany-Bremen-SK-Bremen.html)                                                                           | 576           |             26 |
+| [Germany: Bremen : SK Bremerhaven](html/Germany-Bremen-SK-Bremerhaven.html)                                                                 | 28            |              0 |
+| [Germany: Hamburg : SK Hamburg](html/Germany-Hamburg-SK-Hamburg.html)                                                                       | 4,204         |             91 |
+| [Germany: Hessen : LK Bergstraße](html/Germany-Hessen-LK-Bergstraße.html)                                                                   | 287           |              2 |
+| [Germany: Hessen : LK Darmstadt-Dieburg](html/Germany-Hessen-LK-Darmstadt-Dieburg.html)                                                     | 336           |             11 |
+| [Germany: Hessen : LK Fulda](html/Germany-Hessen-LK-Fulda.html)                                                                             | 288           |              8 |
 | [Germany: Hessen : LK Gießen](html/Germany-Hessen-LK-Gießen.html)                                                                           | 196           |              2 |
-| [Germany: Hessen : LK Groß-Gerau](html/Germany-Hessen-LK-Groß-Gerau.html)                                                                   | 351           |              4 |
+| [Germany: Hessen : LK Groß-Gerau](html/Germany-Hessen-LK-Groß-Gerau.html)                                                                   | 357           |              4 |
 | [Germany: Hessen : LK Hersfeld-Rotenburg](html/Germany-Hessen-LK-Hersfeld-Rotenburg.html)                                                   | 191           |             20 |
-| [Germany: Hessen : LK Hochtaunuskreis](html/Germany-Hessen-LK-Hochtaunuskreis.html)                                                         | 222           |              4 |
-| [Germany: Hessen : LK Kassel](html/Germany-Hessen-LK-Kassel.html)                                                                           | 260           |             18 |
+| [Germany: Hessen : LK Hochtaunuskreis](html/Germany-Hessen-LK-Hochtaunuskreis.html)                                                         | 223           |              4 |
+| [Germany: Hessen : LK Kassel](html/Germany-Hessen-LK-Kassel.html)                                                                           | 263           |             19 |
 | [Germany: Hessen : LK Lahn-Dill-Kreis](html/Germany-Hessen-LK-Lahn-Dill-Kreis.html)                                                         | 318           |             11 |
-| [Germany: Hessen : LK Limburg-Weilburg](html/Germany-Hessen-LK-Limburg-Weilburg.html)                                                       | 235           |              2 |
-| [Germany: Hessen : LK Main-Kinzig-Kreis](html/Germany-Hessen-LK-Main-Kinzig-Kreis.html)                                                     | 488           |             18 |
-| [Germany: Hessen : LK Main-Taunus-Kreis](html/Germany-Hessen-LK-Main-Taunus-Kreis.html)                                                     | 214           |              4 |
-| [Germany: Hessen : LK Marburg-Biedenkopf](html/Germany-Hessen-LK-Marburg-Biedenkopf.html)                                                   | 171           |              1 |
-| [Germany: Hessen : LK Odenwaldkreis](html/Germany-Hessen-LK-Odenwaldkreis.html)                                                             | 252           |             37 |
-| [Germany: Hessen : LK Offenbach](html/Germany-Hessen-LK-Offenbach.html)                                                                     | 396           |             17 |
+| [Germany: Hessen : LK Limburg-Weilburg](html/Germany-Hessen-LK-Limburg-Weilburg.html)                                                       | 236           |              2 |
+| [Germany: Hessen : LK Main-Kinzig-Kreis](html/Germany-Hessen-LK-Main-Kinzig-Kreis.html)                                                     | 498           |             21 |
+| [Germany: Hessen : LK Main-Taunus-Kreis](html/Germany-Hessen-LK-Main-Taunus-Kreis.html)                                                     | 215           |              5 |
+| [Germany: Hessen : LK Marburg-Biedenkopf](html/Germany-Hessen-LK-Marburg-Biedenkopf.html)                                                   | 173           |              1 |
+| [Germany: Hessen : LK Odenwaldkreis](html/Germany-Hessen-LK-Odenwaldkreis.html)                                                             | 262           |             40 |
+| [Germany: Hessen : LK Offenbach](html/Germany-Hessen-LK-Offenbach.html)                                                                     | 397           |             18 |
 | [Germany: Hessen : LK Rheingau-Taunus-Kreis](html/Germany-Hessen-LK-Rheingau-Taunus-Kreis.html)                                             | 190           |              3 |
-| [Germany: Hessen : LK Schwalm-Eder-Kreis](html/Germany-Hessen-LK-Schwalm-Eder-Kreis.html)                                                   | 419           |             25 |
+| [Germany: Hessen : LK Schwalm-Eder-Kreis](html/Germany-Hessen-LK-Schwalm-Eder-Kreis.html)                                                   | 420           |             25 |
 | [Germany: Hessen : LK Vogelsbergkreis](html/Germany-Hessen-LK-Vogelsbergkreis.html)                                                         | 110           |              5 |
-| [Germany: Hessen : LK Waldeck-Frankenberg](html/Germany-Hessen-LK-Waldeck-Frankenberg.html)                                                 | 133           |              3 |
+| [Germany: Hessen : LK Waldeck-Frankenberg](html/Germany-Hessen-LK-Waldeck-Frankenberg.html)                                                 | 136           |              3 |
 | [Germany: Hessen : LK Werra-Meißner-Kreis](html/Germany-Hessen-LK-Werra-Meißner-Kreis.html)                                                 | 122           |              7 |
-| [Germany: Hessen : LK Wetteraukreis](html/Germany-Hessen-LK-Wetteraukreis.html)                                                             | 241           |              7 |
-| [Germany: Hessen : SK Darmstadt](html/Germany-Hessen-SK-Darmstadt.html)                                                                     | 158           |              4 |
-| [Germany: Hessen : SK Frankfurt am Main](html/Germany-Hessen-SK-Frankfurt-am-Main.html)                                                     | 1,064         |             20 |
-| [Germany: Hessen : SK Kassel](html/Germany-Hessen-SK-Kassel.html)                                                                           | 194           |              5 |
-| [Germany: Hessen : SK Offenbach](html/Germany-Hessen-SK-Offenbach.html)                                                                     | 71            |              4 |
-| [Germany: Hessen : SK Wiesbaden](html/Germany-Hessen-SK-Wiesbaden.html)                                                                     | 280           |              9 |
+| [Germany: Hessen : LK Wetteraukreis](html/Germany-Hessen-LK-Wetteraukreis.html)                                                             | 244           |              7 |
+| [Germany: Hessen : SK Darmstadt](html/Germany-Hessen-SK-Darmstadt.html)                                                                     | 159           |              5 |
+| [Germany: Hessen : SK Frankfurt am Main](html/Germany-Hessen-SK-Frankfurt-am-Main.html)                                                     | 1,093         |             23 |
+| [Germany: Hessen : SK Kassel](html/Germany-Hessen-SK-Kassel.html)                                                                           | 196           |              5 |
+| [Germany: Hessen : SK Offenbach](html/Germany-Hessen-SK-Offenbach.html)                                                                     | 72            |              5 |
+| [Germany: Hessen : SK Wiesbaden](html/Germany-Hessen-SK-Wiesbaden.html)                                                                     | 281           |              9 |
 | [Germany: Mecklenburg-Vorpommern : LK Ludwigslust-Parchim](html/Germany-Mecklenburg-Vorpommern-LK-Ludwigslust-Parchim.html)                 | 65            |              1 |
-| [Germany: Mecklenburg-Vorpommern : LK Mecklenburgische Seenplatte](html/Germany-Mecklenburg-Vorpommern-LK-Mecklenburgische-Seenplatte.html) | 107           |              3 |
+| [Germany: Mecklenburg-Vorpommern : LK Mecklenburgische Seenplatte](html/Germany-Mecklenburg-Vorpommern-LK-Mecklenburgische-Seenplatte.html) | 108           |              3 |
 | [Germany: Mecklenburg-Vorpommern : LK Nordwestmecklenburg](html/Germany-Mecklenburg-Vorpommern-LK-Nordwestmecklenburg.html)                 | 68            |              1 |
 | [Germany: Mecklenburg-Vorpommern : LK Rostock](html/Germany-Mecklenburg-Vorpommern-LK-Rostock.html)                                         | 54            |              3 |
 | [Germany: Mecklenburg-Vorpommern : LK Vorpommern-Greifswald](html/Germany-Mecklenburg-Vorpommern-LK-Vorpommern-Greifswald.html)             | 120           |              4 |
 | [Germany: Mecklenburg-Vorpommern : LK Vorpommern-Rügen](html/Germany-Mecklenburg-Vorpommern-LK-Vorpommern-Rügen.html)                       | 76            |              2 |
-| [Germany: Mecklenburg-Vorpommern : SK Rostock](html/Germany-Mecklenburg-Vorpommern-SK-Rostock.html)                                         | 74            |              1 |
+| [Germany: Mecklenburg-Vorpommern : SK Rostock](html/Germany-Mecklenburg-Vorpommern-SK-Rostock.html)                                         | 75            |              1 |
 | [Germany: Mecklenburg-Vorpommern : SK Schwerin](html/Germany-Mecklenburg-Vorpommern-SK-Schwerin.html)                                       | 89            |              0 |
-| [Germany: Niedersachsen : LK Ammerland](html/Germany-Niedersachsen-LK-Ammerland.html)                                                       | 154           |              3 |
-| [Germany: Niedersachsen : LK Aurich](html/Germany-Niedersachsen-LK-Aurich.html)                                                             | 72            |              4 |
-| [Germany: Niedersachsen : LK Celle](html/Germany-Niedersachsen-LK-Celle.html)                                                               | 144           |              7 |
+| [Germany: Niedersachsen : LK Ammerland](html/Germany-Niedersachsen-LK-Ammerland.html)                                                       | 155           |              3 |
+| [Germany: Niedersachsen : LK Aurich](html/Germany-Niedersachsen-LK-Aurich.html)                                                             | 76            |              4 |
+| [Germany: Niedersachsen : LK Celle](html/Germany-Niedersachsen-LK-Celle.html)                                                               | 143           |              8 |
 | [Germany: Niedersachsen : LK Cloppenburg](html/Germany-Niedersachsen-LK-Cloppenburg.html)                                                   | 88            |              0 |
-| [Germany: Niedersachsen : LK Cuxhaven](html/Germany-Niedersachsen-LK-Cuxhaven.html)                                                         | 78            |              3 |
-| [Germany: Niedersachsen : LK Diepholz](html/Germany-Niedersachsen-LK-Diepholz.html)                                                         | 292           |             16 |
-| [Germany: Niedersachsen : LK Emsland](html/Germany-Niedersachsen-LK-Emsland.html)                                                           | 364           |             14 |
-| [Germany: Niedersachsen : LK Friesland](html/Germany-Niedersachsen-LK-Friesland.html)                                                       | 29            |              1 |
-| [Germany: Niedersachsen : LK Gifhorn](html/Germany-Niedersachsen-LK-Gifhorn.html)                                                           | 119           |              3 |
-| [Germany: Niedersachsen : LK Goslar](html/Germany-Niedersachsen-LK-Goslar.html)                                                             | 140           |              7 |
+| [Germany: Niedersachsen : LK Cuxhaven](html/Germany-Niedersachsen-LK-Cuxhaven.html)                                                         | 81            |              3 |
+| [Germany: Niedersachsen : LK Diepholz](html/Germany-Niedersachsen-LK-Diepholz.html)                                                         | 294           |             20 |
+| [Germany: Niedersachsen : LK Emsland](html/Germany-Niedersachsen-LK-Emsland.html)                                                           | 369           |             14 |
+| [Germany: Niedersachsen : LK Friesland](html/Germany-Niedersachsen-LK-Friesland.html)                                                       | 30            |              1 |
+| [Germany: Niedersachsen : LK Gifhorn](html/Germany-Niedersachsen-LK-Gifhorn.html)                                                           | 121           |              4 |
+| [Germany: Niedersachsen : LK Goslar](html/Germany-Niedersachsen-LK-Goslar.html)                                                             | 163           |              9 |
 | [Germany: Niedersachsen : LK Grafschaft Bentheim](html/Germany-Niedersachsen-LK-Grafschaft-Bentheim.html)                                   | 205           |             10 |
-| [Germany: Niedersachsen : LK Göttingen](html/Germany-Niedersachsen-LK-Göttingen.html)                                                       | 579           |             19 |
+| [Germany: Niedersachsen : LK Göttingen](html/Germany-Niedersachsen-LK-Göttingen.html)                                                       | 610           |             30 |
 | [Germany: Niedersachsen : LK Hameln-Pyrmont](html/Germany-Niedersachsen-LK-Hameln-Pyrmont.html)                                             | 107           |              6 |
-| [Germany: Niedersachsen : LK Harburg](html/Germany-Niedersachsen-LK-Harburg.html)                                                           | 426           |              8 |
-| [Germany: Niedersachsen : LK Heidekreis](html/Germany-Niedersachsen-LK-Heidekreis.html)                                                     | 62            |              1 |
-| [Germany: Niedersachsen : LK Helmstedt](html/Germany-Niedersachsen-LK-Helmstedt.html)                                                       | 121           |              0 |
-| [Germany: Niedersachsen : LK Hildesheim](html/Germany-Niedersachsen-LK-Hildesheim.html)                                                     | 252           |              1 |
+| [Germany: Niedersachsen : LK Harburg](html/Germany-Niedersachsen-LK-Harburg.html)                                                           | 435           |              9 |
+| [Germany: Niedersachsen : LK Heidekreis](html/Germany-Niedersachsen-LK-Heidekreis.html)                                                     | 63            |              1 |
+| [Germany: Niedersachsen : LK Helmstedt](html/Germany-Niedersachsen-LK-Helmstedt.html)                                                       | 122           |              0 |
+| [Germany: Niedersachsen : LK Hildesheim](html/Germany-Niedersachsen-LK-Hildesheim.html)                                                     | 258           |              1 |
 | [Germany: Niedersachsen : LK Holzminden](html/Germany-Niedersachsen-LK-Holzminden.html)                                                     | 100           |              5 |
 | [Germany: Niedersachsen : LK Leer](html/Germany-Niedersachsen-LK-Leer.html)                                                                 | 85            |              2 |
 | [Germany: Niedersachsen : LK Lüchow-Dannenberg](html/Germany-Niedersachsen-LK-Lüchow-Dannenberg.html)                                       | 15            |              2 |
-| [Germany: Niedersachsen : LK Lüneburg](html/Germany-Niedersachsen-LK-Lüneburg.html)                                                         | 157           |              0 |
-| [Germany: Niedersachsen : LK Nienburg (Weser)](html/Germany-Niedersachsen-LK-Nienburg-(Weser).html)                                         | 62            |              1 |
+| [Germany: Niedersachsen : LK Lüneburg](html/Germany-Niedersachsen-LK-Lüneburg.html)                                                         | 160           |              0 |
+| [Germany: Niedersachsen : LK Nienburg (Weser)](html/Germany-Niedersachsen-LK-Nienburg-(Weser).html)                                         | 63            |              1 |
 | [Germany: Niedersachsen : LK Northeim](html/Germany-Niedersachsen-LK-Northeim.html)                                                         | 96            |              0 |
-| [Germany: Niedersachsen : LK Oldenburg](html/Germany-Niedersachsen-LK-Oldenburg.html)                                                       | 190           |              9 |
-| [Germany: Niedersachsen : LK Osnabrück](html/Germany-Niedersachsen-LK-Osnabrück.html)                                                       | 856           |             27 |
+| [Germany: Niedersachsen : LK Oldenburg](html/Germany-Niedersachsen-LK-Oldenburg.html)                                                       | 193           |              9 |
+| [Germany: Niedersachsen : LK Osnabrück](html/Germany-Niedersachsen-LK-Osnabrück.html)                                                       | 882           |             28 |
 | [Germany: Niedersachsen : LK Osterholz](html/Germany-Niedersachsen-LK-Osterholz.html)                                                       | 73            |              0 |
-| [Germany: Niedersachsen : LK Peine](html/Germany-Niedersachsen-LK-Peine.html)                                                               | 130           |              8 |
-| [Germany: Niedersachsen : LK Rotenburg (Wümme)](html/Germany-Niedersachsen-LK-Rotenburg-(Wümme).html)                                       | 90            |              1 |
-| [Germany: Niedersachsen : LK Schaumburg](html/Germany-Niedersachsen-LK-Schaumburg.html)                                                     | 134           |              4 |
-| [Germany: Niedersachsen : LK Stade](html/Germany-Niedersachsen-LK-Stade.html)                                                               | 174           |              6 |
+| [Germany: Niedersachsen : LK Peine](html/Germany-Niedersachsen-LK-Peine.html)                                                               | 131           |              9 |
+| [Germany: Niedersachsen : LK Rotenburg (Wümme)](html/Germany-Niedersachsen-LK-Rotenburg-(Wümme).html)                                       | 91            |              1 |
+| [Germany: Niedersachsen : LK Schaumburg](html/Germany-Niedersachsen-LK-Schaumburg.html)                                                     | 137           |              5 |
+| [Germany: Niedersachsen : LK Stade](html/Germany-Niedersachsen-LK-Stade.html)                                                               | 177           |              6 |
 | [Germany: Niedersachsen : LK Uelzen](html/Germany-Niedersachsen-LK-Uelzen.html)                                                             | 39            |              0 |
-| [Germany: Niedersachsen : LK Vechta](html/Germany-Niedersachsen-LK-Vechta.html)                                                             | 293           |             10 |
-| [Germany: Niedersachsen : LK Verden](html/Germany-Niedersachsen-LK-Verden.html)                                                             | 112           |              1 |
+| [Germany: Niedersachsen : LK Vechta](html/Germany-Niedersachsen-LK-Vechta.html)                                                             | 299           |             10 |
+| [Germany: Niedersachsen : LK Verden](html/Germany-Niedersachsen-LK-Verden.html)                                                             | 113           |              1 |
 | [Germany: Niedersachsen : LK Wesermarsch](html/Germany-Niedersachsen-LK-Wesermarsch.html)                                                   | 51            |              1 |
 | [Germany: Niedersachsen : LK Wittmund](html/Germany-Niedersachsen-LK-Wittmund.html)                                                         | 24            |              0 |
-| [Germany: Niedersachsen : LK Wolfenbüttel](html/Germany-Niedersachsen-LK-Wolfenbüttel.html)                                                 | 152           |              4 |
-| [Germany: Niedersachsen : Region Hannover](html/Germany-Niedersachsen-Region-Hannover.html)                                                 | 1,674         |             49 |
-| [Germany: Niedersachsen : SK Braunschweig](html/Germany-Niedersachsen-SK-Braunschweig.html)                                                 | 289           |              7 |
+| [Germany: Niedersachsen : LK Wolfenbüttel](html/Germany-Niedersachsen-LK-Wolfenbüttel.html)                                                 | 152           |              5 |
+| [Germany: Niedersachsen : Region Hannover](html/Germany-Niedersachsen-Region-Hannover.html)                                                 | 1,685         |             49 |
+| [Germany: Niedersachsen : SK Braunschweig](html/Germany-Niedersachsen-SK-Braunschweig.html)                                                 | 290           |              7 |
 | [Germany: Niedersachsen : SK Delmenhorst](html/Germany-Niedersachsen-SK-Delmenhorst.html)                                                   | 36            |              2 |
 | [Germany: Niedersachsen : SK Emden](html/Germany-Niedersachsen-SK-Emden.html)                                                               | 15            |              0 |
 | [Germany: Niedersachsen : SK Oldenburg](html/Germany-Niedersachsen-SK-Oldenburg.html)                                                       | 151           |              0 |
-| [Germany: Niedersachsen : SK Osnabrück](html/Germany-Niedersachsen-SK-Osnabrück.html)                                                       | 414           |              8 |
-| [Germany: Niedersachsen : SK Salzgitter](html/Germany-Niedersachsen-SK-Salzgitter.html)                                                     | 115           |              5 |
+| [Germany: Niedersachsen : SK Osnabrück](html/Germany-Niedersachsen-SK-Osnabrück.html)                                                       | 421           |              8 |
+| [Germany: Niedersachsen : SK Salzgitter](html/Germany-Niedersachsen-SK-Salzgitter.html)                                                     | 116           |              5 |
 | [Germany: Niedersachsen : SK Wilhelmshaven](html/Germany-Niedersachsen-SK-Wilhelmshaven.html)                                               | 17            |              0 |
 | [Germany: Niedersachsen : SK Wolfsburg](html/Germany-Niedersachsen-SK-Wolfsburg.html)                                                       | 272           |             48 |
-| [Germany: Nordrhein-Westfalen : LK Borken](html/Germany-Nordrhein-Westfalen-LK-Borken.html)                                                 | 836           |             26 |
-| [Germany: Nordrhein-Westfalen : LK Coesfeld](html/Germany-Nordrhein-Westfalen-LK-Coesfeld.html)                                             | 476           |             16 |
-| [Germany: Nordrhein-Westfalen : LK Düren](html/Germany-Nordrhein-Westfalen-LK-Düren.html)                                                   | 516           |             24 |
-| [Germany: Nordrhein-Westfalen : LK Ennepe-Ruhr-Kreis](html/Germany-Nordrhein-Westfalen-LK-Ennepe-Ruhr-Kreis.html)                           | 362           |              9 |
-| [Germany: Nordrhein-Westfalen : LK Euskirchen](html/Germany-Nordrhein-Westfalen-LK-Euskirchen.html)                                         | 307           |             11 |
-| [Germany: Nordrhein-Westfalen : LK Gütersloh](html/Germany-Nordrhein-Westfalen-LK-Gütersloh.html)                                           | 529           |             15 |
-| [Germany: Nordrhein-Westfalen : LK Heinsberg](html/Germany-Nordrhein-Westfalen-LK-Heinsberg.html)                                           | 1,684         |             53 |
-| [Germany: Nordrhein-Westfalen : LK Herford](html/Germany-Nordrhein-Westfalen-LK-Herford.html)                                               | 293           |              2 |
+| [Germany: Nordrhein-Westfalen : LK Borken](html/Germany-Nordrhein-Westfalen-LK-Borken.html)                                                 | 843           |             26 |
+| [Germany: Nordrhein-Westfalen : LK Coesfeld](html/Germany-Nordrhein-Westfalen-LK-Coesfeld.html)                                             | 479           |             21 |
+| [Germany: Nordrhein-Westfalen : LK Düren](html/Germany-Nordrhein-Westfalen-LK-Düren.html)                                                   | 517           |             24 |
+| [Germany: Nordrhein-Westfalen : LK Ennepe-Ruhr-Kreis](html/Germany-Nordrhein-Westfalen-LK-Ennepe-Ruhr-Kreis.html)                           | 364           |              9 |
+| [Germany: Nordrhein-Westfalen : LK Euskirchen](html/Germany-Nordrhein-Westfalen-LK-Euskirchen.html)                                         | 315           |             11 |
+| [Germany: Nordrhein-Westfalen : LK Gütersloh](html/Germany-Nordrhein-Westfalen-LK-Gütersloh.html)                                           | 574           |             15 |
+| [Germany: Nordrhein-Westfalen : LK Heinsberg](html/Germany-Nordrhein-Westfalen-LK-Heinsberg.html)                                           | 1,690         |             57 |
+| [Germany: Nordrhein-Westfalen : LK Herford](html/Germany-Nordrhein-Westfalen-LK-Herford.html)                                               | 296           |              4 |
 | [Germany: Nordrhein-Westfalen : LK Hochsauerlandkreis](html/Germany-Nordrhein-Westfalen-LK-Hochsauerlandkreis.html)                         | 548           |             13 |
-| [Germany: Nordrhein-Westfalen : LK Höxter](html/Germany-Nordrhein-Westfalen-LK-Höxter.html)                                                 | 259           |              3 |
-| [Germany: Nordrhein-Westfalen : LK Kleve](html/Germany-Nordrhein-Westfalen-LK-Kleve.html)                                                   | 486           |             15 |
-| [Germany: Nordrhein-Westfalen : LK Lippe](html/Germany-Nordrhein-Westfalen-LK-Lippe.html)                                                   | 604           |             18 |
-| [Germany: Nordrhein-Westfalen : LK Mettmann](html/Germany-Nordrhein-Westfalen-LK-Mettmann.html)                                             | 784           |             46 |
+| [Germany: Nordrhein-Westfalen : LK Höxter](html/Germany-Nordrhein-Westfalen-LK-Höxter.html)                                                 | 260           |              5 |
+| [Germany: Nordrhein-Westfalen : LK Kleve](html/Germany-Nordrhein-Westfalen-LK-Kleve.html)                                                   | 501           |             17 |
+| [Germany: Nordrhein-Westfalen : LK Lippe](html/Germany-Nordrhein-Westfalen-LK-Lippe.html)                                                   | 639           |             22 |
+| [Germany: Nordrhein-Westfalen : LK Mettmann](html/Germany-Nordrhein-Westfalen-LK-Mettmann.html)                                             | 739           |             48 |
 | [Germany: Nordrhein-Westfalen : LK Minden-Lübbecke](html/Germany-Nordrhein-Westfalen-LK-Minden-Lübbecke.html)                               | 394           |              5 |
 | [Germany: Nordrhein-Westfalen : LK Märkischer Kreis](html/Germany-Nordrhein-Westfalen-LK-Märkischer-Kreis.html)                             | 463           |             16 |
-| [Germany: Nordrhein-Westfalen : LK Oberbergischer Kreis](html/Germany-Nordrhein-Westfalen-LK-Oberbergischer-Kreis.html)                     | 394           |             10 |
-| [Germany: Nordrhein-Westfalen : LK Olpe](html/Germany-Nordrhein-Westfalen-LK-Olpe.html)                                                     | 482           |             19 |
-| [Germany: Nordrhein-Westfalen : LK Paderborn](html/Germany-Nordrhein-Westfalen-LK-Paderborn.html)                                           | 527           |             23 |
-| [Germany: Nordrhein-Westfalen : LK Recklinghausen](html/Germany-Nordrhein-Westfalen-LK-Recklinghausen.html)                                 | 843           |             11 |
-| [Germany: Nordrhein-Westfalen : LK Rhein-Erft-Kreis](html/Germany-Nordrhein-Westfalen-LK-Rhein-Erft-Kreis.html)                             | 874           |             44 |
-| [Germany: Nordrhein-Westfalen : LK Rhein-Kreis Neuss](html/Germany-Nordrhein-Westfalen-LK-Rhein-Kreis-Neuss.html)                           | 551           |             16 |
-| [Germany: Nordrhein-Westfalen : LK Rhein-Sieg-Kreis](html/Germany-Nordrhein-Westfalen-LK-Rhein-Sieg-Kreis.html)                             | 1,082         |             23 |
-| [Germany: Nordrhein-Westfalen : LK Rheinisch-Bergischer Kreis](html/Germany-Nordrhein-Westfalen-LK-Rheinisch-Bergischer-Kreis.html)         | 387           |             11 |
-| [Germany: Nordrhein-Westfalen : LK Siegen-Wittgenstein](html/Germany-Nordrhein-Westfalen-LK-Siegen-Wittgenstein.html)                       | 246           |              6 |
-| [Germany: Nordrhein-Westfalen : LK Soest](html/Germany-Nordrhein-Westfalen-LK-Soest.html)                                                   | 332           |              4 |
-| [Germany: Nordrhein-Westfalen : LK Steinfurt](html/Germany-Nordrhein-Westfalen-LK-Steinfurt.html)                                           | 1,121         |             45 |
-| [Germany: Nordrhein-Westfalen : LK Unna](html/Germany-Nordrhein-Westfalen-LK-Unna.html)                                                     | 535           |             20 |
-| [Germany: Nordrhein-Westfalen : LK Viersen](html/Germany-Nordrhein-Westfalen-LK-Viersen.html)                                               | 538           |             26 |
-| [Germany: Nordrhein-Westfalen : LK Warendorf](html/Germany-Nordrhein-Westfalen-LK-Warendorf.html)                                           | 422           |              7 |
-| [Germany: Nordrhein-Westfalen : LK Wesel](html/Germany-Nordrhein-Westfalen-LK-Wesel.html)                                                   | 448           |             14 |
-| [Germany: Nordrhein-Westfalen : SK Bielefeld](html/Germany-Nordrhein-Westfalen-SK-Bielefeld.html)                                           | 338           |              1 |
-| [Germany: Nordrhein-Westfalen : SK Bochum](html/Germany-Nordrhein-Westfalen-SK-Bochum.html)                                                 | 403           |             15 |
-| [Germany: Nordrhein-Westfalen : SK Bonn](html/Germany-Nordrhein-Westfalen-SK-Bonn.html)                                                     | 571           |              5 |
+| [Germany: Nordrhein-Westfalen : LK Oberbergischer Kreis](html/Germany-Nordrhein-Westfalen-LK-Oberbergischer-Kreis.html)                     | 422           |             11 |
+| [Germany: Nordrhein-Westfalen : LK Olpe](html/Germany-Nordrhein-Westfalen-LK-Olpe.html)                                                     | 488           |             23 |
+| [Germany: Nordrhein-Westfalen : LK Paderborn](html/Germany-Nordrhein-Westfalen-LK-Paderborn.html)                                           | 541           |             24 |
+| [Germany: Nordrhein-Westfalen : LK Recklinghausen](html/Germany-Nordrhein-Westfalen-LK-Recklinghausen.html)                                 | 879           |             13 |
+| [Germany: Nordrhein-Westfalen : LK Rhein-Erft-Kreis](html/Germany-Nordrhein-Westfalen-LK-Rhein-Erft-Kreis.html)                             | 882           |             47 |
+| [Germany: Nordrhein-Westfalen : LK Rhein-Kreis Neuss](html/Germany-Nordrhein-Westfalen-LK-Rhein-Kreis-Neuss.html)                           | 553           |             17 |
+| [Germany: Nordrhein-Westfalen : LK Rhein-Sieg-Kreis](html/Germany-Nordrhein-Westfalen-LK-Rhein-Sieg-Kreis.html)                             | 1,086         |             24 |
+| [Germany: Nordrhein-Westfalen : LK Rheinisch-Bergischer Kreis](html/Germany-Nordrhein-Westfalen-LK-Rheinisch-Bergischer-Kreis.html)         | 395           |             11 |
+| [Germany: Nordrhein-Westfalen : LK Siegen-Wittgenstein](html/Germany-Nordrhein-Westfalen-LK-Siegen-Wittgenstein.html)                       | 248           |              6 |
+| [Germany: Nordrhein-Westfalen : LK Soest](html/Germany-Nordrhein-Westfalen-LK-Soest.html)                                                   | 330           |              4 |
+| [Germany: Nordrhein-Westfalen : LK Steinfurt](html/Germany-Nordrhein-Westfalen-LK-Steinfurt.html)                                           | 1,141         |             47 |
+| [Germany: Nordrhein-Westfalen : LK Unna](html/Germany-Nordrhein-Westfalen-LK-Unna.html)                                                     | 539           |             21 |
+| [Germany: Nordrhein-Westfalen : LK Viersen](html/Germany-Nordrhein-Westfalen-LK-Viersen.html)                                               | 542           |             24 |
+| [Germany: Nordrhein-Westfalen : LK Warendorf](html/Germany-Nordrhein-Westfalen-LK-Warendorf.html)                                           | 424           |              7 |
+| [Germany: Nordrhein-Westfalen : LK Wesel](html/Germany-Nordrhein-Westfalen-LK-Wesel.html)                                                   | 455           |             16 |
+| [Germany: Nordrhein-Westfalen : SK Bielefeld](html/Germany-Nordrhein-Westfalen-SK-Bielefeld.html)                                           | 341           |              2 |
+| [Germany: Nordrhein-Westfalen : SK Bochum](html/Germany-Nordrhein-Westfalen-SK-Bochum.html)                                                 | 407           |             15 |
+| [Germany: Nordrhein-Westfalen : SK Bonn](html/Germany-Nordrhein-Westfalen-SK-Bonn.html)                                                     | 578           |              5 |
 | [Germany: Nordrhein-Westfalen : SK Bottrop](html/Germany-Nordrhein-Westfalen-SK-Bottrop.html)                                               | 120           |              5 |
-| [Germany: Nordrhein-Westfalen : SK Dortmund](html/Germany-Nordrhein-Westfalen-SK-Dortmund.html)                                             | 598           |              5 |
-| [Germany: Nordrhein-Westfalen : SK Duisburg](html/Germany-Nordrhein-Westfalen-SK-Duisburg.html)                                             | 649           |             11 |
-| [Germany: Nordrhein-Westfalen : SK Düsseldorf](html/Germany-Nordrhein-Westfalen-SK-Düsseldorf.html)                                         | 909           |             16 |
-| [Germany: Nordrhein-Westfalen : SK Essen](html/Germany-Nordrhein-Westfalen-SK-Essen.html)                                                   | 539           |             28 |
-| [Germany: Nordrhein-Westfalen : SK Gelsenkirchen](html/Germany-Nordrhein-Westfalen-SK-Gelsenkirchen.html)                                   | 248           |              8 |
-| [Germany: Nordrhein-Westfalen : SK Hagen](html/Germany-Nordrhein-Westfalen-SK-Hagen.html)                                                   | 199           |              5 |
-| [Germany: Nordrhein-Westfalen : SK Hamm](html/Germany-Nordrhein-Westfalen-SK-Hamm.html)                                                     | 391           |             21 |
-| [Germany: Nordrhein-Westfalen : SK Herne](html/Germany-Nordrhein-Westfalen-SK-Herne.html)                                                   | 131           |              1 |
-| [Germany: Nordrhein-Westfalen : SK Krefeld](html/Germany-Nordrhein-Westfalen-SK-Krefeld.html)                                               | 368           |              8 |
-| [Germany: Nordrhein-Westfalen : SK Köln](html/Germany-Nordrhein-Westfalen-SK-Köln.html)                                                     | 2,188         |             64 |
-| [Germany: Nordrhein-Westfalen : SK Leverkusen](html/Germany-Nordrhein-Westfalen-SK-Leverkusen.html)                                         | 176           |              3 |
-| [Germany: Nordrhein-Westfalen : SK Mönchengladbach](html/Germany-Nordrhein-Westfalen-SK-Mönchengladbach.html)                               | 422           |             25 |
-| [Germany: Nordrhein-Westfalen : SK Mülheim a.d.Ruhr](html/Germany-Nordrhein-Westfalen-SK-Mülheim-a.d.Ruhr.html)                             | 141           |              4 |
+| [Germany: Nordrhein-Westfalen : SK Dortmund](html/Germany-Nordrhein-Westfalen-SK-Dortmund.html)                                             | 611           |              5 |
+| [Germany: Nordrhein-Westfalen : SK Duisburg](html/Germany-Nordrhein-Westfalen-SK-Duisburg.html)                                             | 683           |             14 |
+| [Germany: Nordrhein-Westfalen : SK Düsseldorf](html/Germany-Nordrhein-Westfalen-SK-Düsseldorf.html)                                         | 926           |             17 |
+| [Germany: Nordrhein-Westfalen : SK Essen](html/Germany-Nordrhein-Westfalen-SK-Essen.html)                                                   | 640           |             30 |
+| [Germany: Nordrhein-Westfalen : SK Gelsenkirchen](html/Germany-Nordrhein-Westfalen-SK-Gelsenkirchen.html)                                   | 274           |              8 |
+| [Germany: Nordrhein-Westfalen : SK Hagen](html/Germany-Nordrhein-Westfalen-SK-Hagen.html)                                                   | 201           |              5 |
+| [Germany: Nordrhein-Westfalen : SK Hamm](html/Germany-Nordrhein-Westfalen-SK-Hamm.html)                                                     | 399           |             23 |
+| [Germany: Nordrhein-Westfalen : SK Herne](html/Germany-Nordrhein-Westfalen-SK-Herne.html)                                                   | 135           |              1 |
+| [Germany: Nordrhein-Westfalen : SK Krefeld](html/Germany-Nordrhein-Westfalen-SK-Krefeld.html)                                               | 414           |             14 |
+| [Germany: Nordrhein-Westfalen : SK Köln](html/Germany-Nordrhein-Westfalen-SK-Köln.html)                                                     | 2,187         |             66 |
+| [Germany: Nordrhein-Westfalen : SK Leverkusen](html/Germany-Nordrhein-Westfalen-SK-Leverkusen.html)                                         | 185           |              3 |
+| [Germany: Nordrhein-Westfalen : SK Mönchengladbach](html/Germany-Nordrhein-Westfalen-SK-Mönchengladbach.html)                               | 425           |             28 |
+| [Germany: Nordrhein-Westfalen : SK Mülheim a.d.Ruhr](html/Germany-Nordrhein-Westfalen-SK-Mülheim-a.d.Ruhr.html)                             | 146           |              4 |
 | [Germany: Nordrhein-Westfalen : SK Münster](html/Germany-Nordrhein-Westfalen-SK-Münster.html)                                               | 612           |             10 |
-| [Germany: Nordrhein-Westfalen : SK Oberhausen](html/Germany-Nordrhein-Westfalen-SK-Oberhausen.html)                                         | 158           |              1 |
-| [Germany: Nordrhein-Westfalen : SK Remscheid](html/Germany-Nordrhein-Westfalen-SK-Remscheid.html)                                           | 196           |              3 |
-| [Germany: Nordrhein-Westfalen : SK Solingen](html/Germany-Nordrhein-Westfalen-SK-Solingen.html)                                             | 203           |              3 |
-| [Germany: Nordrhein-Westfalen : SK Wuppertal](html/Germany-Nordrhein-Westfalen-SK-Wuppertal.html)                                           | 709           |             37 |
-| [Germany: Nordrhein-Westfalen : StadtRegion Aachen](html/Germany-Nordrhein-Westfalen-StadtRegion-Aachen.html)                               | 1,657         |             63 |
+| [Germany: Nordrhein-Westfalen : SK Oberhausen](html/Germany-Nordrhein-Westfalen-SK-Oberhausen.html)                                         | 160           |              1 |
+| [Germany: Nordrhein-Westfalen : SK Remscheid](html/Germany-Nordrhein-Westfalen-SK-Remscheid.html)                                           | 200           |              8 |
+| [Germany: Nordrhein-Westfalen : SK Solingen](html/Germany-Nordrhein-Westfalen-SK-Solingen.html)                                             | 211           |              4 |
+| [Germany: Nordrhein-Westfalen : SK Wuppertal](html/Germany-Nordrhein-Westfalen-SK-Wuppertal.html)                                           | 730           |             38 |
+| [Germany: Nordrhein-Westfalen : StadtRegion Aachen](html/Germany-Nordrhein-Westfalen-StadtRegion-Aachen.html)                               | 1,666         |             65 |
 | [Germany: Rheinland-Pfalz : LK Ahrweiler](html/Germany-Rheinland-Pfalz-LK-Ahrweiler.html)                                                   | 114           |              1 |
-| [Germany: Rheinland-Pfalz : LK Altenkirchen](html/Germany-Rheinland-Pfalz-LK-Altenkirchen.html)                                             | 118           |              5 |
-| [Germany: Rheinland-Pfalz : LK Alzey-Worms](html/Germany-Rheinland-Pfalz-LK-Alzey-Worms.html)                                               | 163           |              3 |
-| [Germany: Rheinland-Pfalz : LK Bad Dürkheim](html/Germany-Rheinland-Pfalz-LK-Bad-Dürkheim.html)                                             | 303           |              6 |
-| [Germany: Rheinland-Pfalz : LK Bad Kreuznach](html/Germany-Rheinland-Pfalz-LK-Bad-Kreuznach.html)                                           | 166           |              2 |
-| [Germany: Rheinland-Pfalz : LK Bernkastel-Wittlich](html/Germany-Rheinland-Pfalz-LK-Bernkastel-Wittlich.html)                               | 122           |              1 |
-| [Germany: Rheinland-Pfalz : LK Birkenfeld](html/Germany-Rheinland-Pfalz-LK-Birkenfeld.html)                                                 | 74            |              0 |
-| [Germany: Rheinland-Pfalz : LK Bitburg-Prüm](html/Germany-Rheinland-Pfalz-LK-Bitburg-Prüm.html)                                             | 157           |              3 |
+| [Germany: Rheinland-Pfalz : LK Altenkirchen](html/Germany-Rheinland-Pfalz-LK-Altenkirchen.html)                                             | 118           |              7 |
+| [Germany: Rheinland-Pfalz : LK Alzey-Worms](html/Germany-Rheinland-Pfalz-LK-Alzey-Worms.html)                                               | 166           |              3 |
+| [Germany: Rheinland-Pfalz : LK Bad Dürkheim](html/Germany-Rheinland-Pfalz-LK-Bad-Dürkheim.html)                                             | 304           |              6 |
+| [Germany: Rheinland-Pfalz : LK Bad Kreuznach](html/Germany-Rheinland-Pfalz-LK-Bad-Kreuznach.html)                                           | 173           |              2 |
+| [Germany: Rheinland-Pfalz : LK Bernkastel-Wittlich](html/Germany-Rheinland-Pfalz-LK-Bernkastel-Wittlich.html)                               | 123           |              1 |
+| [Germany: Rheinland-Pfalz : LK Birkenfeld](html/Germany-Rheinland-Pfalz-LK-Birkenfeld.html)                                                 | 77            |              0 |
+| [Germany: Rheinland-Pfalz : LK Bitburg-Prüm](html/Germany-Rheinland-Pfalz-LK-Bitburg-Prüm.html)                                             | 158           |              3 |
 | [Germany: Rheinland-Pfalz : LK Cochem-Zell](html/Germany-Rheinland-Pfalz-LK-Cochem-Zell.html)                                               | 125           |              1 |
-| [Germany: Rheinland-Pfalz : LK Donnersbergkreis](html/Germany-Rheinland-Pfalz-LK-Donnersbergkreis.html)                                     | 105           |              2 |
-| [Germany: Rheinland-Pfalz : LK Germersheim](html/Germany-Rheinland-Pfalz-LK-Germersheim.html)                                               | 130           |              3 |
+| [Germany: Rheinland-Pfalz : LK Donnersbergkreis](html/Germany-Rheinland-Pfalz-LK-Donnersbergkreis.html)                                     | 109           |              2 |
+| [Germany: Rheinland-Pfalz : LK Germersheim](html/Germany-Rheinland-Pfalz-LK-Germersheim.html)                                               | 131           |              3 |
 | [Germany: Rheinland-Pfalz : LK Kaiserslautern](html/Germany-Rheinland-Pfalz-LK-Kaiserslautern.html)                                         | 95            |              0 |
-| [Germany: Rheinland-Pfalz : LK Kusel](html/Germany-Rheinland-Pfalz-LK-Kusel.html)                                                           | 84            |              0 |
-| [Germany: Rheinland-Pfalz : LK Mainz-Bingen](html/Germany-Rheinland-Pfalz-LK-Mainz-Bingen.html)                                             | 336           |             10 |
-| [Germany: Rheinland-Pfalz : LK Mayen-Koblenz](html/Germany-Rheinland-Pfalz-LK-Mayen-Koblenz.html)                                           | 332           |              7 |
+| [Germany: Rheinland-Pfalz : LK Kusel](html/Germany-Rheinland-Pfalz-LK-Kusel.html)                                                           | 85            |              0 |
+| [Germany: Rheinland-Pfalz : LK Mainz-Bingen](html/Germany-Rheinland-Pfalz-LK-Mainz-Bingen.html)                                             | 337           |             10 |
+| [Germany: Rheinland-Pfalz : LK Mayen-Koblenz](html/Germany-Rheinland-Pfalz-LK-Mayen-Koblenz.html)                                           | 333           |              7 |
 | [Germany: Rheinland-Pfalz : LK Neuwied](html/Germany-Rheinland-Pfalz-LK-Neuwied.html)                                                       | 214           |              3 |
-| [Germany: Rheinland-Pfalz : LK Rhein-Hunsrück-Kreis](html/Germany-Rheinland-Pfalz-LK-Rhein-Hunsrück-Kreis.html)                             | 156           |              2 |
+| [Germany: Rheinland-Pfalz : LK Rhein-Hunsrück-Kreis](html/Germany-Rheinland-Pfalz-LK-Rhein-Hunsrück-Kreis.html)                             | 157           |              2 |
 | [Germany: Rheinland-Pfalz : LK Rhein-Lahn-Kreis](html/Germany-Rheinland-Pfalz-LK-Rhein-Lahn-Kreis.html)                                     | 149           |              4 |
 | [Germany: Rheinland-Pfalz : LK Rhein-Pfalz-Kreis](html/Germany-Rheinland-Pfalz-LK-Rhein-Pfalz-Kreis.html)                                   | 193           |              2 |
 | [Germany: Rheinland-Pfalz : LK Südliche Weinstraße](html/Germany-Rheinland-Pfalz-LK-Südliche-Weinstraße.html)                               | 140           |              1 |
 | [Germany: Rheinland-Pfalz : LK Südwestpfalz](html/Germany-Rheinland-Pfalz-LK-Südwestpfalz.html)                                             | 103           |              2 |
 | [Germany: Rheinland-Pfalz : LK Trier-Saarburg](html/Germany-Rheinland-Pfalz-LK-Trier-Saarburg.html)                                         | 165           |              4 |
-| [Germany: Rheinland-Pfalz : LK Vulkaneifel](html/Germany-Rheinland-Pfalz-LK-Vulkaneifel.html)                                               | 102           |              2 |
-| [Germany: Rheinland-Pfalz : LK Westerwaldkreis](html/Germany-Rheinland-Pfalz-LK-Westerwaldkreis.html)                                       | 314           |             17 |
+| [Germany: Rheinland-Pfalz : LK Vulkaneifel](html/Germany-Rheinland-Pfalz-LK-Vulkaneifel.html)                                               | 106           |              2 |
+| [Germany: Rheinland-Pfalz : LK Westerwaldkreis](html/Germany-Rheinland-Pfalz-LK-Westerwaldkreis.html)                                       | 315           |             20 |
 | [Germany: Rheinland-Pfalz : SK Frankenthal](html/Germany-Rheinland-Pfalz-SK-Frankenthal.html)                                               | 36            |              2 |
-| [Germany: Rheinland-Pfalz : SK Kaiserslautern](html/Germany-Rheinland-Pfalz-SK-Kaiserslautern.html)                                         | 106           |              1 |
-| [Germany: Rheinland-Pfalz : SK Koblenz](html/Germany-Rheinland-Pfalz-SK-Koblenz.html)                                                       | 236           |             11 |
+| [Germany: Rheinland-Pfalz : SK Kaiserslautern](html/Germany-Rheinland-Pfalz-SK-Kaiserslautern.html)                                         | 107           |              1 |
+| [Germany: Rheinland-Pfalz : SK Koblenz](html/Germany-Rheinland-Pfalz-SK-Koblenz.html)                                                       | 237           |             11 |
 | [Germany: Rheinland-Pfalz : SK Landau i.d.Pfalz](html/Germany-Rheinland-Pfalz-SK-Landau-i.d.Pfalz.html)                                     | 52            |              0 |
 | [Germany: Rheinland-Pfalz : SK Ludwigshafen](html/Germany-Rheinland-Pfalz-SK-Ludwigshafen.html)                                             | 252           |              1 |
-| [Germany: Rheinland-Pfalz : SK Mainz](html/Germany-Rheinland-Pfalz-SK-Mainz.html)                                                           | 436           |             12 |
+| [Germany: Rheinland-Pfalz : SK Mainz](html/Germany-Rheinland-Pfalz-SK-Mainz.html)                                                           | 440           |             13 |
 | [Germany: Rheinland-Pfalz : SK Neustadt a.d.Weinstraße](html/Germany-Rheinland-Pfalz-SK-Neustadt-a.d.Weinstraße.html)                       | 90            |              1 |
 | [Germany: Rheinland-Pfalz : SK Pirmasens](html/Germany-Rheinland-Pfalz-SK-Pirmasens.html)                                                   | 30            |              0 |
 | [Germany: Rheinland-Pfalz : SK Speyer](html/Germany-Rheinland-Pfalz-SK-Speyer.html)                                                         | 55            |              0 |
 | [Germany: Rheinland-Pfalz : SK Trier](html/Germany-Rheinland-Pfalz-SK-Trier.html)                                                           | 94            |              1 |
 | [Germany: Rheinland-Pfalz : SK Worms](html/Germany-Rheinland-Pfalz-SK-Worms.html)                                                           | 159           |              6 |
 | [Germany: Rheinland-Pfalz : SK Zweibrücken](html/Germany-Rheinland-Pfalz-SK-Zweibrücken.html)                                               | 35            |              0 |
-| [Germany: Saarland : LK Merzig-Wadern](html/Germany-Saarland-LK-Merzig-Wadern.html)                                                         | 181           |              1 |
-| [Germany: Saarland : LK Neunkirchen](html/Germany-Saarland-LK-Neunkirchen.html)                                                             | 217           |              4 |
-| [Germany: Saarland : LK Saar-Pfalz-Kreis](html/Germany-Saarland-LK-Saar-Pfalz-Kreis.html)                                                   | 259           |              7 |
-| [Germany: Saarland : LK Saarlouis](html/Germany-Saarland-LK-Saarlouis.html)                                                                 | 451           |             15 |
+| [Germany: Saarland : LK Merzig-Wadern](html/Germany-Saarland-LK-Merzig-Wadern.html)                                                         | 182           |              1 |
+| [Germany: Saarland : LK Neunkirchen](html/Germany-Saarland-LK-Neunkirchen.html)                                                             | 219           |              4 |
+| [Germany: Saarland : LK Saar-Pfalz-Kreis](html/Germany-Saarland-LK-Saar-Pfalz-Kreis.html)                                                   | 261           |              7 |
+| [Germany: Saarland : LK Saarlouis](html/Germany-Saarland-LK-Saarlouis.html)                                                                 | 455           |             15 |
 | [Germany: Saarland : LK Sankt Wendel](html/Germany-Saarland-LK-Sankt-Wendel.html)                                                           | 133           |              4 |
-| [Germany: Saarland : LK Stadtverband Saarbrücken](html/Germany-Saarland-LK-Stadtverband-Saarbrücken.html)                                   | 1,079         |             62 |
-| [Germany: Sachsen : LK Bautzen](html/Germany-Sachsen-LK-Bautzen.html)                                                                       | 311           |              7 |
-| [Germany: Sachsen : LK Erzgebirgskreis](html/Germany-Sachsen-LK-Erzgebirgskreis.html)                                                       | 470           |             35 |
-| [Germany: Sachsen : LK Görlitz](html/Germany-Sachsen-LK-Görlitz.html)                                                                       | 240           |             14 |
-| [Germany: Sachsen : LK Leipzig](html/Germany-Sachsen-LK-Leipzig.html)                                                                       | 180           |              4 |
-| [Germany: Sachsen : LK Meißen](html/Germany-Sachsen-LK-Meißen.html)                                                                         | 192           |             12 |
+| [Germany: Saarland : LK Stadtverband Saarbrücken](html/Germany-Saarland-LK-Stadtverband-Saarbrücken.html)                                   | 1,091         |             66 |
+| [Germany: Sachsen : LK Bautzen](html/Germany-Sachsen-LK-Bautzen.html)                                                                       | 310           |             10 |
+| [Germany: Sachsen : LK Erzgebirgskreis](html/Germany-Sachsen-LK-Erzgebirgskreis.html)                                                       | 471           |             35 |
+| [Germany: Sachsen : LK Görlitz](html/Germany-Sachsen-LK-Görlitz.html)                                                                       | 241           |             14 |
+| [Germany: Sachsen : LK Leipzig](html/Germany-Sachsen-LK-Leipzig.html)                                                                       | 181           |              4 |
+| [Germany: Sachsen : LK Meißen](html/Germany-Sachsen-LK-Meißen.html)                                                                         | 195           |             12 |
 | [Germany: Sachsen : LK Mittelsachsen](html/Germany-Sachsen-LK-Mittelsachsen.html)                                                           | 237           |              2 |
-| [Germany: Sachsen : LK Nordsachsen](html/Germany-Sachsen-LK-Nordsachsen.html)                                                               | 119           |              0 |
-| [Germany: Sachsen : LK Sächsische Schweiz-Osterzgebirge](html/Germany-Sachsen-LK-Sächsische-Schweiz-Osterzgebirge.html)                     | 316           |              2 |
-| [Germany: Sachsen : LK Vogtlandkreis](html/Germany-Sachsen-LK-Vogtlandkreis.html)                                                           | 280           |              4 |
-| [Germany: Sachsen : LK Zwickau](html/Germany-Sachsen-LK-Zwickau.html)                                                                       | 713           |             25 |
-| [Germany: Sachsen : SK Chemnitz](html/Germany-Sachsen-SK-Chemnitz.html)                                                                     | 188           |              3 |
-| [Germany: Sachsen : SK Dresden](html/Germany-Sachsen-SK-Dresden.html)                                                                       | 473           |              5 |
-| [Germany: Sachsen : SK Leipzig](html/Germany-Sachsen-SK-Leipzig.html)                                                                       | 524           |              4 |
+| [Germany: Sachsen : LK Nordsachsen](html/Germany-Sachsen-LK-Nordsachsen.html)                                                               | 120           |              0 |
+| [Germany: Sachsen : LK Sächsische Schweiz-Osterzgebirge](html/Germany-Sachsen-LK-Sächsische-Schweiz-Osterzgebirge.html)                     | 320           |              2 |
+| [Germany: Sachsen : LK Vogtlandkreis](html/Germany-Sachsen-LK-Vogtlandkreis.html)                                                           | 285           |              4 |
+| [Germany: Sachsen : LK Zwickau](html/Germany-Sachsen-LK-Zwickau.html)                                                                       | 701           |             25 |
+| [Germany: Sachsen : SK Chemnitz](html/Germany-Sachsen-SK-Chemnitz.html)                                                                     | 189           |              4 |
+| [Germany: Sachsen : SK Dresden](html/Germany-Sachsen-SK-Dresden.html)                                                                       | 476           |              5 |
+| [Germany: Sachsen : SK Leipzig](html/Germany-Sachsen-SK-Leipzig.html)                                                                       | 526           |              4 |
 | [Germany: Sachsen-Anhalt : LK Altmarkkreis Salzwedel](html/Germany-Sachsen-Anhalt-LK-Altmarkkreis-Salzwedel.html)                           | 30            |              0 |
-| [Germany: Sachsen-Anhalt : LK Anhalt-Bitterfeld](html/Germany-Sachsen-Anhalt-LK-Anhalt-Bitterfeld.html)                                     | 58            |              0 |
-| [Germany: Sachsen-Anhalt : LK Burgenlandkreis](html/Germany-Sachsen-Anhalt-LK-Burgenlandkreis.html)                                         | 68            |              1 |
-| [Germany: Sachsen-Anhalt : LK Börde](html/Germany-Sachsen-Anhalt-LK-Börde.html)                                                             | 101           |              3 |
+| [Germany: Sachsen-Anhalt : LK Anhalt-Bitterfeld](html/Germany-Sachsen-Anhalt-LK-Anhalt-Bitterfeld.html)                                     | 60            |              0 |
+| [Germany: Sachsen-Anhalt : LK Burgenlandkreis](html/Germany-Sachsen-Anhalt-LK-Burgenlandkreis.html)                                         | 69            |              1 |
+| [Germany: Sachsen-Anhalt : LK Börde](html/Germany-Sachsen-Anhalt-LK-Börde.html)                                                             | 103           |              4 |
 | [Germany: Sachsen-Anhalt : LK Harz](html/Germany-Sachsen-Anhalt-LK-Harz.html)                                                               | 217           |              3 |
 | [Germany: Sachsen-Anhalt : LK Jerichower Land](html/Germany-Sachsen-Anhalt-LK-Jerichower-Land.html)                                         | 31            |              1 |
-| [Germany: Sachsen-Anhalt : LK Mansfeld-Südharz](html/Germany-Sachsen-Anhalt-LK-Mansfeld-Südharz.html)                                       | 34            |              1 |
-| [Germany: Sachsen-Anhalt : LK Saalekreis](html/Germany-Sachsen-Anhalt-LK-Saalekreis.html)                                                   | 103           |              4 |
+| [Germany: Sachsen-Anhalt : LK Mansfeld-Südharz](html/Germany-Sachsen-Anhalt-LK-Mansfeld-Südharz.html)                                       | 35            |              1 |
+| [Germany: Sachsen-Anhalt : LK Saalekreis](html/Germany-Sachsen-Anhalt-LK-Saalekreis.html)                                                   | 106           |              4 |
 | [Germany: Sachsen-Anhalt : LK Salzlandkreis](html/Germany-Sachsen-Anhalt-LK-Salzlandkreis.html)                                             | 62            |              0 |
 | [Germany: Sachsen-Anhalt : LK Stendal](html/Germany-Sachsen-Anhalt-LK-Stendal.html)                                                         | 85            |              5 |
-| [Germany: Sachsen-Anhalt : LK Wittenberg](html/Germany-Sachsen-Anhalt-LK-Wittenberg.html)                                                   | 148           |              3 |
+| [Germany: Sachsen-Anhalt : LK Wittenberg](html/Germany-Sachsen-Anhalt-LK-Wittenberg.html)                                                   | 149           |              3 |
 | [Germany: Sachsen-Anhalt : SK Dessau-Roßlau](html/Germany-Sachsen-Anhalt-SK-Dessau-Roßlau.html)                                             | 59            |              1 |
-| [Germany: Sachsen-Anhalt : SK Halle](html/Germany-Sachsen-Anhalt-SK-Halle.html)                                                             | 279           |              9 |
+| [Germany: Sachsen-Anhalt : SK Halle](html/Germany-Sachsen-Anhalt-SK-Halle.html)                                                             | 281           |              9 |
 | [Germany: Sachsen-Anhalt : SK Magdeburg](html/Germany-Sachsen-Anhalt-SK-Magdeburg.html)                                                     | 101           |              1 |
 | [Germany: Schleswig-Holstein : LK Dithmarschen](html/Germany-Schleswig-Holstein-LK-Dithmarschen.html)                                       | 54            |              3 |
-| [Germany: Schleswig-Holstein : LK Herzogtum Lauenburg](html/Germany-Schleswig-Holstein-LK-Herzogtum-Lauenburg.html)                         | 225           |              6 |
+| [Germany: Schleswig-Holstein : LK Herzogtum Lauenburg](html/Germany-Schleswig-Holstein-LK-Herzogtum-Lauenburg.html)                         | 234           |              6 |
 | [Germany: Schleswig-Holstein : LK Nordfriesland](html/Germany-Schleswig-Holstein-LK-Nordfriesland.html)                                     | 69            |              1 |
 | [Germany: Schleswig-Holstein : LK Ostholstein](html/Germany-Schleswig-Holstein-LK-Ostholstein.html)                                         | 59            |              0 |
-| [Germany: Schleswig-Holstein : LK Pinneberg](html/Germany-Schleswig-Holstein-LK-Pinneberg.html)                                             | 492           |             18 |
+| [Germany: Schleswig-Holstein : LK Pinneberg](html/Germany-Schleswig-Holstein-LK-Pinneberg.html)                                             | 495           |             18 |
 | [Germany: Schleswig-Holstein : LK Plön](html/Germany-Schleswig-Holstein-LK-Plön.html)                                                       | 104           |              4 |
-| [Germany: Schleswig-Holstein : LK Rendsburg-Eckernförde](html/Germany-Schleswig-Holstein-LK-Rendsburg-Eckernförde.html)                     | 215           |             12 |
+| [Germany: Schleswig-Holstein : LK Rendsburg-Eckernförde](html/Germany-Schleswig-Holstein-LK-Rendsburg-Eckernförde.html)                     | 219           |             12 |
 | [Germany: Schleswig-Holstein : LK Schleswig-Flensburg](html/Germany-Schleswig-Holstein-LK-Schleswig-Flensburg.html)                         | 117           |              3 |
-| [Germany: Schleswig-Holstein : LK Segeberg](html/Germany-Schleswig-Holstein-LK-Segeberg.html)                                               | 207           |              2 |
+| [Germany: Schleswig-Holstein : LK Segeberg](html/Germany-Schleswig-Holstein-LK-Segeberg.html)                                               | 208           |              3 |
 | [Germany: Schleswig-Holstein : LK Steinburg](html/Germany-Schleswig-Holstein-LK-Steinburg.html)                                             | 79            |              3 |
-| [Germany: Schleswig-Holstein : LK Stormarn](html/Germany-Schleswig-Holstein-LK-Stormarn.html)                                               | 336           |              9 |
-| [Germany: Schleswig-Holstein : SK Flensburg](html/Germany-Schleswig-Holstein-SK-Flensburg.html)                                             | -31           |             -2 |
-| [Germany: Schleswig-Holstein : SK Kiel](html/Germany-Schleswig-Holstein-SK-Kiel.html)                                                       | 221           |              7 |
-| [Germany: Schleswig-Holstein : SK Lübeck](html/Germany-Schleswig-Holstein-SK-Lübeck.html)                                                   | 152           |              1 |
+| [Germany: Schleswig-Holstein : LK Stormarn](html/Germany-Schleswig-Holstein-LK-Stormarn.html)                                               | 348           |             14 |
+| [Germany: Schleswig-Holstein : SK Flensburg](html/Germany-Schleswig-Holstein-SK-Flensburg.html)                                             | 33            |              2 |
+| [Germany: Schleswig-Holstein : SK Kiel](html/Germany-Schleswig-Holstein-SK-Kiel.html)                                                       | 235           |              7 |
+| [Germany: Schleswig-Holstein : SK Lübeck](html/Germany-Schleswig-Holstein-SK-Lübeck.html)                                                   | 154           |              1 |
 | [Germany: Schleswig-Holstein : SK Neumünster](html/Germany-Schleswig-Holstein-SK-Neumünster.html)                                           | 50            |              1 |
-| [Germany: Thüringen : LK Altenburger Land](html/Germany-Thüringen-LK-Altenburger-Land.html)                                                 | 40            |              3 |
+| [Germany: Thüringen : LK Altenburger Land](html/Germany-Thüringen-LK-Altenburger-Land.html)                                                 | 43            |              3 |
 | [Germany: Thüringen : LK Eichsfeld](html/Germany-Thüringen-LK-Eichsfeld.html)                                                               | 108           |              3 |
-| [Germany: Thüringen : LK Gotha](html/Germany-Thüringen-LK-Gotha.html)                                                                       | 123           |              3 |
-| [Germany: Thüringen : LK Greiz](html/Germany-Thüringen-LK-Greiz.html)                                                                       | 311           |             16 |
+| [Germany: Thüringen : LK Gotha](html/Germany-Thüringen-LK-Gotha.html)                                                                       | 131           |              3 |
+| [Germany: Thüringen : LK Greiz](html/Germany-Thüringen-LK-Greiz.html)                                                                       | 311           |             18 |
 | [Germany: Thüringen : LK Hildburghausen](html/Germany-Thüringen-LK-Hildburghausen.html)                                                     | 18            |              1 |
-| [Germany: Thüringen : LK Ilm-Kreis](html/Germany-Thüringen-LK-Ilm-Kreis.html)                                                               | 112           |              3 |
-| [Germany: Thüringen : LK Kyffhäuserkreis](html/Germany-Thüringen-LK-Kyffhäuserkreis.html)                                                   | 35            |              0 |
-| [Germany: Thüringen : LK Nordhausen](html/Germany-Thüringen-LK-Nordhausen.html)                                                             | 52            |              1 |
+| [Germany: Thüringen : LK Ilm-Kreis](html/Germany-Thüringen-LK-Ilm-Kreis.html)                                                               | 113           |              4 |
+| [Germany: Thüringen : LK Kyffhäuserkreis](html/Germany-Thüringen-LK-Kyffhäuserkreis.html)                                                   | 36            |              0 |
+| [Germany: Thüringen : LK Nordhausen](html/Germany-Thüringen-LK-Nordhausen.html)                                                             | 53            |              1 |
 | [Germany: Thüringen : LK Saale-Holzland-Kreis](html/Germany-Thüringen-LK-Saale-Holzland-Kreis.html)                                         | 50            |              1 |
-| [Germany: Thüringen : LK Saale-Orla-Kreis](html/Germany-Thüringen-LK-Saale-Orla-Kreis.html)                                                 | 107           |              8 |
+| [Germany: Thüringen : LK Saale-Orla-Kreis](html/Germany-Thüringen-LK-Saale-Orla-Kreis.html)                                                 | 109           |              8 |
 | [Germany: Thüringen : LK Saalfeld-Rudolstadt](html/Germany-Thüringen-LK-Saalfeld-Rudolstadt.html)                                           | 54            |              0 |
-| [Germany: Thüringen : LK Schmalkalden-Meiningen](html/Germany-Thüringen-LK-Schmalkalden-Meiningen.html)                                     | 72            |              1 |
-| [Germany: Thüringen : LK Sonneberg](html/Germany-Thüringen-LK-Sonneberg.html)                                                               | 59            |              1 |
+| [Germany: Thüringen : LK Schmalkalden-Meiningen](html/Germany-Thüringen-LK-Schmalkalden-Meiningen.html)                                     | 74            |              2 |
+| [Germany: Thüringen : LK Sonneberg](html/Germany-Thüringen-LK-Sonneberg.html)                                                               | 60            |              1 |
 | [Germany: Thüringen : LK Sömmerda](html/Germany-Thüringen-LK-Sömmerda.html)                                                                 | 33            |              0 |
-| [Germany: Thüringen : LK Unstrut-Hainich-Kreis](html/Germany-Thüringen-LK-Unstrut-Hainich-Kreis.html)                                       | 62            |              1 |
-| [Germany: Thüringen : LK Wartburgkreis](html/Germany-Thüringen-LK-Wartburgkreis.html)                                                       | 35            |              0 |
-| [Germany: Thüringen : LK Weimarer Land](html/Germany-Thüringen-LK-Weimarer-Land.html)                                                       | 66            |              3 |
+| [Germany: Thüringen : LK Unstrut-Hainich-Kreis](html/Germany-Thüringen-LK-Unstrut-Hainich-Kreis.html)                                       | 64            |              1 |
+| [Germany: Thüringen : LK Wartburgkreis](html/Germany-Thüringen-LK-Wartburgkreis.html)                                                       | 36            |              0 |
+| [Germany: Thüringen : LK Weimarer Land](html/Germany-Thüringen-LK-Weimarer-Land.html)                                                       | 66            |              4 |
 | [Germany: Thüringen : SK Eisenach](html/Germany-Thüringen-SK-Eisenach.html)                                                                 | 14            |              1 |
 | [Germany: Thüringen : SK Erfurt](html/Germany-Thüringen-SK-Erfurt.html)                                                                     | 122           |              2 |
-| [Germany: Thüringen : SK Gera](html/Germany-Thüringen-SK-Gera.html)                                                                         | 91            |              1 |
+| [Germany: Thüringen : SK Gera](html/Germany-Thüringen-SK-Gera.html)                                                                         | 93            |              2 |
 | [Germany: Thüringen : SK Jena](html/Germany-Thüringen-SK-Jena.html)                                                                         | 155           |              3 |
 | [Germany: Thüringen : SK Suhl](html/Germany-Thüringen-SK-Suhl.html)                                                                         | 13            |              2 |
 | [Germany: Thüringen : SK Weimar](html/Germany-Thüringen-SK-Weimar.html)                                                                     | 58            |              0 |

--- a/tools/pelican/content/interactive.md
+++ b/tools/pelican/content/interactive.md
@@ -1,6 +1,5 @@
 title: Interactive plots
-category: Data
-tags: plots, GUI, voila
+tags: Plots, GUI, Voila
 save-as: interactive
 date: 2020-04-08 08:30
 status: draft

--- a/tools/pelican/content/license.md
+++ b/tools/pelican/content/license.md
@@ -1,6 +1,5 @@
 title: License
-category: About
-tags: data, code, license
+tags: About, Data, Code, License
 save-as: license
 date: 2020/04/19 13:00
 

--- a/tools/pelican/content/motivation.md
+++ b/tools/pelican/content/motivation.md
@@ -1,6 +1,6 @@
 Title: Our motivation
 Date: 2020-04-19 10:20
-category: About
+tags: About
 slug: motivation
 
 

--- a/tools/pelican/content/open-science.md
+++ b/tools/pelican/content/open-science.md
@@ -1,8 +1,7 @@
 Title: Open Science
 Date: 2020-04-19 19:00
-category: About
 slug: open-science
-tags: Open Science, source code
+tags: Open Science, Source code, About
 
 
 To use the analysis provided here, some Python knowledge is required, ideally

--- a/tools/pelican/content/plots.md
+++ b/tools/pelican/content/plots.md
@@ -1,8 +1,7 @@
 Title: Standard Plots
 Date: 2020-04-09 19:00
-category: About
 slug: plots
-tags: data, plots
+tags: About, Data, Plots
 
 
 We discuss the plots from the top (number 1) to the bottom (number 7) that are

--- a/tools/pelican/content/team.md
+++ b/tools/pelican/content/team.md
@@ -1,6 +1,6 @@
 Title: Team
 Date: 2020-04-10 21:00
-category: About
+tags: About
 slug: team
 
 Following early work by [Hans Fangohr](http://fangohr.github.io), members of the European research project

--- a/tools/pelican/content/world.md
+++ b/tools/pelican/content/world.md
@@ -1,194 +1,193 @@
 title: World
-category: Data
-tags: data, plots
+tags: Data, Plots, World
 save-as: world
-date: 2020/04/21 07:13
+date: 2020/04/22 11:44
 
 
 | Country/Region                                                                 | Total cases   | Total deaths   |
 |:-------------------------------------------------------------------------------|:--------------|:---------------|
-| [Afghanistan](html/Afghanistan.html)                                           | 1,026         | 36             |
-| [Albania](html/Albania.html)                                                   | 584           | 26             |
-| [Algeria](html/Algeria.html)                                                   | 2,718         | 384            |
+| [Afghanistan](html/Afghanistan.html)                                           | 1,092         | 36             |
+| [Albania](html/Albania.html)                                                   | 609           | 26             |
+| [Algeria](html/Algeria.html)                                                   | 2,811         | 392            |
 | [Andorra](html/Andorra.html)                                                   | 717           | 37             |
 | [Angola](html/Angola.html)                                                     | 24            | 2              |
 | [Antigua and Barbuda](html/Antigua and Barbuda.html)                           | 23            | 3              |
-| [Argentina](html/Argentina.html)                                               | 2,941         | 136            |
-| [Armenia](html/Armenia.html)                                                   | 1,339         | 22             |
+| [Argentina](html/Argentina.html)                                               | 3,031         | 147            |
+| [Armenia](html/Armenia.html)                                                   | 1,401         | 24             |
 | [Australia](html/Australia.html)                                               | 6,547         | 67             |
-| [Austria](html/Austria.html)                                                   | 14,795        | 470            |
-| [Azerbaijan](html/Azerbaijan.html)                                             | 1,436         | 19             |
-| [Bahamas](html/Bahamas.html)                                                   | 60            | 9              |
-| [Bahrain](html/Bahrain.html)                                                   | 1,907         | 7              |
-| [Bangladesh](html/Bangladesh.html)                                             | 2,948         | 101            |
+| [Austria](html/Austria.html)                                                   | 14,873        | 491            |
+| [Azerbaijan](html/Azerbaijan.html)                                             | 1,480         | 20             |
+| [Bahamas](html/Bahamas.html)                                                   | 65            | 9              |
+| [Bahrain](html/Bahrain.html)                                                   | 1,973         | 7              |
+| [Bangladesh](html/Bangladesh.html)                                             | 3,382         | 110            |
 | [Barbados](html/Barbados.html)                                                 | 75            | 5              |
-| [Belarus](html/Belarus.html)                                                   | 6,264         | 51             |
-| [Belgium](html/Belgium.html)                                                   | 39,983        | 5,828          |
+| [Belarus](html/Belarus.html)                                                   | 6,723         | 55             |
+| [Belgium](html/Belgium.html)                                                   | 40,956        | 5,998          |
 | [Belize](html/Belize.html)                                                     | 18            | 2              |
 | [Benin](html/Benin.html)                                                       | 54            | 1              |
-| [Bhutan](html/Bhutan.html)                                                     | 5             | 0              |
-| [Bolivia](html/Bolivia.html)                                                   | 564           | 33             |
-| [Bosnia and Herzegovina](html/Bosnia and Herzegovina.html)                     | 1,309         | 49             |
+| [Bhutan](html/Bhutan.html)                                                     | 6             | 0              |
+| [Bolivia](html/Bolivia.html)                                                   | 598           | 34             |
+| [Bosnia and Herzegovina](html/Bosnia and Herzegovina.html)                     | 1,342         | 51             |
 | [Botswana](html/Botswana.html)                                                 | 20            | 1              |
-| [Brazil](html/Brazil.html)                                                     | 40,743        | 2,587          |
+| [Brazil](html/Brazil.html)                                                     | 43,079        | 2,741          |
 | [Brunei](html/Brunei.html)                                                     | 138           | 1              |
-| [Bulgaria](html/Bulgaria.html)                                                 | 929           | 43             |
-| [Burkina Faso](html/Burkina Faso.html)                                         | 581           | 38             |
-| [Burma](html/Burma.html)                                                       | 119           | 5              |
+| [Bulgaria](html/Bulgaria.html)                                                 | 975           | 45             |
+| [Burkina Faso](html/Burkina Faso.html)                                         | 600           | 38             |
+| [Burma](html/Burma.html)                                                       | 121           | 5              |
 | [Burundi](html/Burundi.html)                                                   | 5             | 1              |
-| [Cabo Verde](html/Cabo Verde.html)                                             | 67            | 1              |
+| [Cabo Verde](html/Cabo Verde.html)                                             | 68            | 1              |
 | [Cambodia](html/Cambodia.html)                                                 | 122           | 0              |
-| [Cameroon](html/Cameroon.html)                                                 | 1,163         | 42             |
-| [Canada](html/Canada.html)                                                     | 37,657        | 1,725          |
-| [Central African Republic](html/Central African Republic.html)                 | 12            | 0              |
+| [Cameroon](html/Cameroon.html)                                                 | 1,163         | 43             |
+| [Canada](html/Canada.html)                                                     | 39,401        | 1,908          |
+| [Central African Republic](html/Central African Republic.html)                 | 14            | 0              |
 | [Chad](html/Chad.html)                                                         | 33            | 0              |
-| [Chile](html/Chile.html)                                                       | 10,507        | 139            |
-| [China](html/China.html)                                                       | 83,817        | 4,636          |
-| [Colombia](html/Colombia.html)                                                 | 3,977         | 189            |
-| [Congo (Brazzaville)](html/Congo (Brazzaville).html)                           | 160           | 6              |
-| [Congo (Kinshasa)](html/Congo (Kinshasa).html)                                 | 332           | 25             |
-| [Costa Rica](html/Costa Rica.html)                                             | 662           | 6              |
-| [Cote d'Ivoire](html/Cote d'Ivoire.html)                                       | 847           | 9              |
-| [Croatia](html/Croatia.html)                                                   | 1,881         | 47             |
-| [Cuba](html/Cuba.html)                                                         | 1,087         | 36             |
-| [Cyprus](html/Cyprus.html)                                                     | 772           | 12             |
-| [Czechia](html/Czechia.html)                                                   | 6,900         | 194            |
-| [Denmark](html/Denmark.html)                                                   | 7,711         | 364            |
+| [Chile](html/Chile.html)                                                       | 10,832        | 147            |
+| [China](html/China.html)                                                       | 83,853        | 4,636          |
+| [Colombia](html/Colombia.html)                                                 | 4,149         | 196            |
+| [Congo (Brazzaville)](html/Congo (Brazzaville).html)                           | 165           | 6              |
+| [Congo (Kinshasa)](html/Congo (Kinshasa).html)                                 | 350           | 25             |
+| [Costa Rica](html/Costa Rica.html)                                             | 669           | 6              |
+| [Cote d'Ivoire](html/Cote d'Ivoire.html)                                       | 916           | 13             |
+| [Croatia](html/Croatia.html)                                                   | 1,908         | 48             |
+| [Cuba](html/Cuba.html)                                                         | 1,137         | 38             |
+| [Cyprus](html/Cyprus.html)                                                     | 784           | 12             |
+| [Czechia](html/Czechia.html)                                                   | 7,033         | 201            |
+| [Denmark](html/Denmark.html)                                                   | 7,891         | 370            |
 | [Diamond Princess](html/Diamond Princess.html)                                 | 712           | 13             |
-| [Djibouti](html/Djibouti.html)                                                 | 846           | 2              |
+| [Djibouti](html/Djibouti.html)                                                 | 945           | 2              |
 | [Dominica](html/Dominica.html)                                                 | 16            | 0              |
-| [Dominican Republic](html/Dominican Republic.html)                             | 4,964         | 235            |
-| [Ecuador](html/Ecuador.html)                                                   | 10,128        | 507            |
-| [Egypt](html/Egypt.html)                                                       | 3,333         | 250            |
-| [El Salvador](html/El Salvador.html)                                           | 218           | 7              |
-| [Equatorial Guinea](html/Equatorial Guinea.html)                               | 79            | 0              |
+| [Dominican Republic](html/Dominican Republic.html)                             | 5,044         | 245            |
+| [Ecuador](html/Ecuador.html)                                                   | 10,398        | 520            |
+| [Egypt](html/Egypt.html)                                                       | 3,490         | 264            |
+| [El Salvador](html/El Salvador.html)                                           | 225           | 7              |
+| [Equatorial Guinea](html/Equatorial Guinea.html)                               | 83            | 0              |
 | [Eritrea](html/Eritrea.html)                                                   | 39            | 0              |
-| [Estonia](html/Estonia.html)                                                   | 1,535         | 40             |
-| [Eswatini](html/Eswatini.html)                                                 | 24            | 1              |
-| [Ethiopia](html/Ethiopia.html)                                                 | 111           | 3              |
+| [Estonia](html/Estonia.html)                                                   | 1,552         | 43             |
+| [Eswatini](html/Eswatini.html)                                                 | 31            | 1              |
+| [Ethiopia](html/Ethiopia.html)                                                 | 114           | 3              |
 | [Fiji](html/Fiji.html)                                                         | 18            | 0              |
-| [Finland](html/Finland.html)                                                   | 3,868         | 98             |
-| [France](html/France.html)                                                     | 156,480       | 20,292         |
-| [Gabon](html/Gabon.html)                                                       | 120           | 1              |
+| [Finland](html/Finland.html)                                                   | 4,014         | 141            |
+| [France](html/France.html)                                                     | 159,297       | 20,829         |
+| [Gabon](html/Gabon.html)                                                       | 156           | 1              |
 | [Gambia](html/Gambia.html)                                                     | 10            | 1              |
-| [Georgia](html/Georgia.html)                                                   | 402           | 4              |
-| [Germany](html/Germany.html)                                                   | 147,065       | 4,862          |
+| [Georgia](html/Georgia.html)                                                   | 408           | 4              |
+| [Germany](html/Germany.html)                                                   | 148,291       | 5,033          |
 | [Ghana](html/Ghana.html)                                                       | 1,042         | 9              |
-| [Greece](html/Greece.html)                                                     | 2,245         | 116            |
+| [Greece](html/Greece.html)                                                     | 2,401         | 121            |
 | [Grenada](html/Grenada.html)                                                   | 14            | 0              |
-| [Guatemala](html/Guatemala.html)                                               | 289           | 7              |
-| [Guinea](html/Guinea.html)                                                     | 622           | 5              |
+| [Guatemala](html/Guatemala.html)                                               | 294           | 7              |
+| [Guinea](html/Guinea.html)                                                     | 688           | 6              |
 | [Guinea-Bissau](html/Guinea-Bissau.html)                                       | 50            | 0              |
-| [Guyana](html/Guyana.html)                                                     | 65            | 7              |
+| [Guyana](html/Guyana.html)                                                     | 66            | 7              |
 | [Haiti](html/Haiti.html)                                                       | 57            | 3              |
 | [Holy See](html/Holy See.html)                                                 | 9             | 0              |
-| [Honduras](html/Honduras.html)                                                 | 477           | 46             |
-| [Hungary](html/Hungary.html)                                                   | 1,984         | 199            |
-| [Iceland](html/Iceland.html)                                                   | 1,773         | 10             |
-| [India](html/India.html)                                                       | 18,539        | 592            |
-| [Indonesia](html/Indonesia.html)                                               | 6,760         | 590            |
-| [Iran](html/Iran.html)                                                         | 83,505        | 5,209          |
-| [Iraq](html/Iraq.html)                                                         | 1,574         | 82             |
-| [Ireland](html/Ireland.html)                                                   | 15,652        | 687            |
-| [Israel](html/Israel.html)                                                     | 13,713        | 177            |
-| [Italy](html/Italy.html)                                                       | 181,228       | 24,114         |
-| [Jamaica](html/Jamaica.html)                                                   | 223           | 5              |
-| [Japan](html/Japan.html)                                                       | 10,797        | 236            |
-| [Jordan](html/Jordan.html)                                                     | 425           | 7              |
-| [Kazakhstan](html/Kazakhstan.html)                                             | 1,852         | 19             |
-| [Kenya](html/Kenya.html)                                                       | 281           | 14             |
-| [Korea, South](html/Korea, South.html)                                         | 10,674        | 236            |
+| [Honduras](html/Honduras.html)                                                 | 494           | 46             |
+| [Hungary](html/Hungary.html)                                                   | 2,098         | 213            |
+| [Iceland](html/Iceland.html)                                                   | 1,778         | 10             |
+| [India](html/India.html)                                                       | 20,080        | 645            |
+| [Indonesia](html/Indonesia.html)                                               | 7,135         | 616            |
+| [Iran](html/Iran.html)                                                         | 84,802        | 5,297          |
+| [Iraq](html/Iraq.html)                                                         | 1,602         | 83             |
+| [Ireland](html/Ireland.html)                                                   | 16,040        | 730            |
+| [Israel](html/Israel.html)                                                     | 13,942        | 184            |
+| [Italy](html/Italy.html)                                                       | 183,957       | 24,648         |
+| [Jamaica](html/Jamaica.html)                                                   | 223           | 6              |
+| [Japan](html/Japan.html)                                                       | 11,135        | 263            |
+| [Jordan](html/Jordan.html)                                                     | 428           | 7              |
+| [Kazakhstan](html/Kazakhstan.html)                                             | 1,995         | 19             |
+| [Kenya](html/Kenya.html)                                                       | 296           | 14             |
+| [Korea, South](html/Korea, South.html)                                         | 10,683        | 237            |
 | [Kosovo](html/Kosovo.html)                                                     | 510           | 12             |
-| [Kuwait](html/Kuwait.html)                                                     | 1,995         | 9              |
-| [Kyrgyzstan](html/Kyrgyzstan.html)                                             | 568           | 7              |
+| [Kuwait](html/Kuwait.html)                                                     | 2,080         | 11             |
+| [Kyrgyzstan](html/Kyrgyzstan.html)                                             | 590           | 7              |
 | [Laos](html/Laos.html)                                                         | 19            | 0              |
-| [Latvia](html/Latvia.html)                                                     | 739           | 5              |
+| [Latvia](html/Latvia.html)                                                     | 748           | 9              |
 | [Lebanon](html/Lebanon.html)                                                   | 677           | 21             |
-| [Liberia](html/Liberia.html)                                                   | 99            | 8              |
+| [Liberia](html/Liberia.html)                                                   | 101           | 8              |
 | [Libya](html/Libya.html)                                                       | 51            | 1              |
 | [Liechtenstein](html/Liechtenstein.html)                                       | 81            | 1              |
-| [Lithuania](html/Lithuania.html)                                               | 1,326         | 37             |
-| [Luxembourg](html/Luxembourg.html)                                             | 3,558         | 75             |
+| [Lithuania](html/Lithuania.html)                                               | 1,350         | 38             |
+| [Luxembourg](html/Luxembourg.html)                                             | 3,618         | 78             |
 | [MS Zaandam](html/MS Zaandam.html)                                             | 9             | 2              |
 | [Madagascar](html/Madagascar.html)                                             | 121           | 0              |
-| [Malawi](html/Malawi.html)                                                     | 17            | 2              |
-| [Malaysia](html/Malaysia.html)                                                 | 5,425         | 89             |
-| [Maldives](html/Maldives.html)                                                 | 69            | 0              |
-| [Mali](html/Mali.html)                                                         | 246           | 14             |
-| [Malta](html/Malta.html)                                                       | 431           | 3              |
+| [Malawi](html/Malawi.html)                                                     | 18            | 2              |
+| [Malaysia](html/Malaysia.html)                                                 | 5,482         | 92             |
+| [Maldives](html/Maldives.html)                                                 | 83            | 0              |
+| [Mali](html/Mali.html)                                                         | 258           | 14             |
+| [Malta](html/Malta.html)                                                       | 443           | 3              |
 | [Mauritania](html/Mauritania.html)                                             | 7             | 1              |
 | [Mauritius](html/Mauritius.html)                                               | 328           | 9              |
-| [Mexico](html/Mexico.html)                                                     | 8,261         | 686            |
-| [Moldova](html/Moldova.html)                                                   | 2,548         | 70             |
+| [Mexico](html/Mexico.html)                                                     | 8,772         | 712            |
+| [Moldova](html/Moldova.html)                                                   | 2,614         | 72             |
 | [Monaco](html/Monaco.html)                                                     | 94            | 3              |
-| [Mongolia](html/Mongolia.html)                                                 | 33            | 0              |
-| [Montenegro](html/Montenegro.html)                                             | 312           | 5              |
-| [Morocco](html/Morocco.html)                                                   | 3,046         | 143            |
+| [Mongolia](html/Mongolia.html)                                                 | 34            | 0              |
+| [Montenegro](html/Montenegro.html)                                             | 313           | 5              |
+| [Morocco](html/Morocco.html)                                                   | 3,209         | 145            |
 | [Mozambique](html/Mozambique.html)                                             | 39            | 0              |
 | [Namibia](html/Namibia.html)                                                   | 16            | 0              |
-| [Nepal](html/Nepal.html)                                                       | 31            | 0              |
-| [Netherlands](html/Netherlands.html)                                           | 33,588        | 3,764          |
-| [New Zealand](html/New Zealand.html)                                           | 1,440         | 12             |
+| [Nepal](html/Nepal.html)                                                       | 43            | 0              |
+| [Netherlands](html/Netherlands.html)                                           | 34,317        | 3,929          |
+| [New Zealand](html/New Zealand.html)                                           | 1,445         | 13             |
 | [Nicaragua](html/Nicaragua.html)                                               | 10            | 2              |
-| [Niger](html/Niger.html)                                                       | 648           | 20             |
+| [Niger](html/Niger.html)                                                       | 657           | 20             |
 | [Nigeria](html/Nigeria.html)                                                   | 665           | 22             |
-| [North Macedonia](html/North Macedonia.html)                                   | 1,225         | 54             |
-| [Norway](html/Norway.html)                                                     | 7,156         | 181            |
-| [Oman](html/Oman.html)                                                         | 1,410         | 7              |
-| [Pakistan](html/Pakistan.html)                                                 | 8,418         | 176            |
-| [Panama](html/Panama.html)                                                     | 4,467         | 126            |
+| [North Macedonia](html/North Macedonia.html)                                   | 1,231         | 55             |
+| [Norway](html/Norway.html)                                                     | 7,191         | 182            |
+| [Oman](html/Oman.html)                                                         | 1,508         | 8              |
+| [Pakistan](html/Pakistan.html)                                                 | 9,565         | 201            |
+| [Panama](html/Panama.html)                                                     | 4,658         | 136            |
 | [Papua New Guinea](html/Papua New Guinea.html)                                 | 7             | 0              |
 | [Paraguay](html/Paraguay.html)                                                 | 208           | 8              |
-| [Peru](html/Peru.html)                                                         | 16,325        | 445            |
-| [Philippines](html/Philippines.html)                                           | 6,459         | 428            |
-| [Poland](html/Poland.html)                                                     | 9,593         | 380            |
-| [Portugal](html/Portugal.html)                                                 | 20,863        | 735            |
-| [Qatar](html/Qatar.html)                                                       | 6,015         | 9              |
-| [Romania](html/Romania.html)                                                   | 8,936         | 478            |
-| [Russia](html/Russia.html)                                                     | 47,121        | 405            |
-| [Rwanda](html/Rwanda.html)                                                     | 147           | 0              |
+| [Peru](html/Peru.html)                                                         | 17,837        | 484            |
+| [Philippines](html/Philippines.html)                                           | 6,599         | 437            |
+| [Poland](html/Poland.html)                                                     | 9,856         | 401            |
+| [Portugal](html/Portugal.html)                                                 | 21,379        | 762            |
+| [Qatar](html/Qatar.html)                                                       | 6,533         | 9              |
+| [Romania](html/Romania.html)                                                   | 9,242         | 498            |
+| [Russia](html/Russia.html)                                                     | 52,763        | 456            |
+| [Rwanda](html/Rwanda.html)                                                     | 150           | 0              |
 | [Saint Kitts and Nevis](html/Saint Kitts and Nevis.html)                       | 15            | 0              |
 | [Saint Lucia](html/Saint Lucia.html)                                           | 15            | 0              |
 | [Saint Vincent and the Grenadines](html/Saint Vincent and the Grenadines.html) | 12            | 0              |
-| [San Marino](html/San Marino.html)                                             | 462           | 39             |
+| [San Marino](html/San Marino.html)                                             | 476           | 40             |
 | [Sao Tome and Principe](html/Sao Tome and Principe.html)                       | 4             | 0              |
-| [Saudi Arabia](html/Saudi Arabia.html)                                         | 10,484        | 103            |
-| [Senegal](html/Senegal.html)                                                   | 377           | 5              |
+| [Saudi Arabia](html/Saudi Arabia.html)                                         | 11,631        | 109            |
+| [Senegal](html/Senegal.html)                                                   | 412           | 5              |
 | [Serbia](html/Serbia.html)                                                     | 6,630         | 125            |
 | [Seychelles](html/Seychelles.html)                                             | 11            | 0              |
-| [Sierra Leone](html/Sierra Leone.html)                                         | 43            | 0              |
-| [Singapore](html/Singapore.html)                                               | 8,014         | 11             |
-| [Slovakia](html/Slovakia.html)                                                 | 1,173         | 13             |
-| [Slovenia](html/Slovenia.html)                                                 | 1,335         | 77             |
-| [Somalia](html/Somalia.html)                                                   | 237           | 8              |
-| [South Africa](html/South Africa.html)                                         | 3,300         | 58             |
+| [Sierra Leone](html/Sierra Leone.html)                                         | 50            | 0              |
+| [Singapore](html/Singapore.html)                                               | 9,125         | 11             |
+| [Slovakia](html/Slovakia.html)                                                 | 1,199         | 14             |
+| [Slovenia](html/Slovenia.html)                                                 | 1,344         | 77             |
+| [Somalia](html/Somalia.html)                                                   | 286           | 8              |
+| [South Africa](html/South Africa.html)                                         | 3,465         | 58             |
 | [South Sudan](html/South Sudan.html)                                           | 4             | 0              |
-| [Spain](html/Spain.html)                                                       | 200,210       | 20,852         |
-| [Sri Lanka](html/Sri Lanka.html)                                               | 304           | 7              |
+| [Spain](html/Spain.html)                                                       | 204,178       | 21,282         |
+| [Sri Lanka](html/Sri Lanka.html)                                               | 310           | 7              |
 | [Sudan](html/Sudan.html)                                                       | 107           | 12             |
 | [Suriname](html/Suriname.html)                                                 | 10            | 1              |
-| [Sweden](html/Sweden.html)                                                     | 14,777        | 1,580          |
-| [Switzerland](html/Switzerland.html)                                           | 27,944        | 1,429          |
-| [Syria](html/Syria.html)                                                       | 39            | 3              |
-| [Taiwan*](html/Taiwan*.html)                                                   | 422           | 6              |
+| [Sweden](html/Sweden.html)                                                     | 15,322        | 1,765          |
+| [Switzerland](html/Switzerland.html)                                           | 28,063        | 1,478          |
+| [Syria](html/Syria.html)                                                       | 42            | 3              |
+| [Taiwan*](html/Taiwan*.html)                                                   | 425           | 6              |
 | [Tanzania](html/Tanzania.html)                                                 | 254           | 10             |
-| [Thailand](html/Thailand.html)                                                 | 2,792         | 47             |
-| [Timor-Leste](html/Timor-Leste.html)                                           | 22            | 0              |
-| [Togo](html/Togo.html)                                                         | 84            | 6              |
-| [Trinidad and Tobago](html/Trinidad and Tobago.html)                           | 114           | 8              |
+| [Thailand](html/Thailand.html)                                                 | 2,811         | 48             |
+| [Timor-Leste](html/Timor-Leste.html)                                           | 23            | 0              |
+| [Togo](html/Togo.html)                                                         | 86            | 6              |
+| [Trinidad and Tobago](html/Trinidad and Tobago.html)                           | 115           | 8              |
 | [Tunisia](html/Tunisia.html)                                                   | 884           | 38             |
-| [Turkey](html/Turkey.html)                                                     | 90,980        | 2,140          |
-| [US](html/US.html)                                                             | 784,326       | 42,094         |
-| [Uganda](html/Uganda.html)                                                     | 56            | 0              |
-| [Ukraine](html/Ukraine.html)                                                   | 5,710         | 151            |
-| [United Arab Emirates](html/United Arab Emirates.html)                         | 7,265         | 43             |
-| [United Kingdom](html/United Kingdom.html)                                     | 125,856       | 16,550         |
-| [Uruguay](html/Uruguay.html)                                                   | 535           | 10             |
-| [Uzbekistan](html/Uzbekistan.html)                                             | 1,627         | 5              |
-| [Venezuela](html/Venezuela.html)                                               | 256           | 9              |
+| [Turkey](html/Turkey.html)                                                     | 95,591        | 2,259          |
+| [US](html/US.html)                                                             | 823,786       | 44,845         |
+| [Uganda](html/Uganda.html)                                                     | 61            | 0              |
+| [Ukraine](html/Ukraine.html)                                                   | 6,125         | 161            |
+| [United Arab Emirates](html/United Arab Emirates.html)                         | 7,755         | 46             |
+| [United Kingdom](html/United Kingdom.html)                                     | 130,172       | 17,378         |
+| [Uruguay](html/Uruguay.html)                                                   | 535           | 11             |
+| [Uzbekistan](html/Uzbekistan.html)                                             | 1,678         | 6              |
+| [Venezuela](html/Venezuela.html)                                               | 285           | 10             |
 | [Vietnam](html/Vietnam.html)                                                   | 268           | 0              |
-| [West Bank and Gaza](html/West Bank and Gaza.html)                             | 449           | 3              |
+| [West Bank and Gaza](html/West Bank and Gaza.html)                             | 466           | 4              |
 | [Western Sahara](html/Western Sahara.html)                                     | 6             | 0              |
 | [Yemen](html/Yemen.html)                                                       | 1             | 0              |
-| [Zambia](html/Zambia.html)                                                     | 65            | 3              |
-| [Zimbabwe](html/Zimbabwe.html)                                                 | 25            | 3              |
+| [Zambia](html/Zambia.html)                                                     | 70            | 3              |
+| [Zimbabwe](html/Zimbabwe.html)                                                 | 28            | 3              |

--- a/tools/pelican/pelicanconf.py
+++ b/tools/pelican/pelicanconf.py
@@ -19,11 +19,17 @@ TRANSLATION_FEED_ATOM = None
 AUTHOR_FEED_ATOM = None
 AUTHOR_FEED_RSS = None
 
+MENUITEMS = [("Home", "index.html"),
+             ("World", "world.html"),
+             ("Germany", "germany.html"),
+             ("Data", "tag-data.html"),
+             ("About", "tag-about.html")]
+
 OUTPUT_PATH = "../wwwroot"
 
 # Blogroll
-LINKS = (("PaNOSC project", "https://panosc.eu"),
-         )
+LINKS = [("PaNOSC project", "www.panosc.eu"),
+         ('OSCOVIDA', 'mailto:oscovidaproject@gmail.com')]
          # ('You can modify those links in your config file', '#'),)
 
 # Social widget
@@ -31,7 +37,6 @@ SOCIAL = (('Open Science COVID Analysis', 'https://twitter.com/OSCOVIDAproject')
           ('PaNOSC', 'https://twitter.com/Panosc_eu'),
           ('ProfCompMod', 'https://twitter.com/ProfCompMod'))
           #('Email','oscovidaproject@gmail.com'))
-#          ('Open Science COVID Analysis', 'https://twitter.com/OSCOVIDAproject'))
 
 DEFAULT_PAGINATION = False
 
@@ -41,7 +46,8 @@ STATIC_PATHS = ['content/pages']
 # THEME = "/Users/fangohr/pelican-themes/bootstrap2"
 THEME = "themes/plumage"
 
-#DISPLAY_CATEGORIES_ON_MENU = False
+DISPLAY_CATEGORIES_ON_MENU = False
+DISPLAY_PAGES_ON_MENU = False
 
 # Uncomment following line if you want document-relative URLs when developing
 RELATIVE_URLS = True
@@ -59,18 +65,24 @@ LOAD_CONTENT_CACHE = False
 AUTHOR_SAVE_AS = False
 AUTHORS_SAVE_AS = False
 
-TAGS_SAVE_AS = 'tags/index.html'
-CATEGORIES_SAVE_AS = 'categories/index.html'
-ARCHIVES_SAVE_AS = 'archives/index.html'
+# Define where to save Tags, and categories
+# Use of subdirectories can link to confusion when following links within the webpage,
+# so we stick to a one directory level scheme here for now.
+TAG_SAVE_AS = 'tag-{slug}.html'
+TAG_URL = 'tag-{slug}.html'
+CATEGORY_SAVE_AS = "category-{slug}.html"
+CATEGORY_URL = "category-{slug}.html"
 
-
-COPYRIGHT = """You are welcome to share and use the materials here. See <a href="http://oscovida.github.io/license.html">license</a> for details."""
+# used by 'Browse content by', entry is omitted if set to False (see
+# themes/plumage/templates/base.html)
+ARCHIVES_SAVE_AS = 'archives-index.html'
+TAGS_SAVE_AS = 'tags-index.html'
+CATEGORIES_SAVE_AS = 'categories-index.html'
+CATEGORIES_SAVE_AS = False
 
 COPYRIGHT = """Unless contrary mentioned, the content of this site is published under a <a rel='license'
 href='https://creativecommons.org/licenses/by/4.0/'>Creative Commons
 Attribution 4.0 International license</a>. See <a href="http://oscovida.github.io/license.html">license</a> for details."""
-
-# The software is licensed under  <a href="https://github.com/fangohr/coronavirus-2020/blob/master/LICENSE">BSD 3-clause license</a>.
 
 DISCLAIMER = """Plots, data and software here are provided <a href="https://github.com/fangohr/coronavirus-2020/blob/master/LICENSE#L20">as-is without any warranties</a> by volunteers. Use the material at your own risk. See <a href="http://oscovida.github.io/license.html">license</a> for details."""
 


### PR DESCRIPTION
- menu entries for World and Germany are added as menu items (see screenshot below) as these are important as major attractions of the site
- in the process, noticed that we don't need categories, and can use tags to
label all articles
- changed population of menu line from implicet (through categories) to explicit
  definition in the pelican.conf file
- Replace categories (such as About) with tag (About), and point to list of all
  artciles with tag About instead of using a category. Looks the same to the
  user.
- Tidied up social links
- defined save-as paths so that all pelican metada (such as tag-about.html) is
  saved in the top level directory, and not in subdirectories.

![Screenshot 2020-04-22 at 14 20 10](https://user-images.githubusercontent.com/4489119/79981165-7e7f5b00-84a4-11ea-8c67-62574d6cb839.png)
