### PR TITLE
Embed analytics snippet simple

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 
 test-pelican:
 	cd tools && jupyter-nbconvert --execute generate-individiual-plots.ipynb
-	cd tools/pelican && make publish
+	cd tools/pelican && make html
 
 test-html-creation:
 	@echo "This is a slow test."

--- a/todo.md
+++ b/todo.md
@@ -56,7 +56,7 @@ Webpage generation
 -   \[ \] make webpage generation into a service (cronjob?) to run once
     a day and update webpages automatically
 -   \[ \] document and refactor everything
--   \[ \] Embed google analytics snippet in html of notebooks (in `html/*`)
+-   \[X\] Embed google analytics snippet in html of notebooks (in `html/*`)
 
 Binder
 -------

--- a/tools/pelican/publishconf.py
+++ b/tools/pelican/publishconf.py
@@ -25,3 +25,69 @@ FEED_ALL_ATOM = 'feeds/all.atom.xml'
 #DISQUS_SITENAME = "oscovida"
 #GOOGLE_ANALYTICS = ""
 GOOGLE_ANALYTICS="UA-163845056-1"
+
+
+########################
+
+
+def inject_google_analytics_into_html_notebooks(GOOGLE_ANALYTICS):
+    """embed google analytics script into html generated from notebooks
+
+    (There are probably more elegant ways to do this when we convert from ipynb
+    to html?)
+
+    """
+
+    # Google Analytics snippet from
+    # https://developers.google.com/analytics/devguides/collection/analyticsjs
+
+    snippet = """
+    <!-- Google Analytics -->
+    <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', '""" + GOOGLE_ANALYTICS + """', 'auto');
+    ga('send', 'pageview');
+    </script>
+    <!-- End Google Analytics -->"""
+
+    files = os.listdir('../wwwroot/html')
+
+    counter_injected = 0
+    counter_untouched = 0
+    print(f"Injecting Google Analytics snippet ... ", end="")
+    for file in files:
+        with open(os.path.join("../wwwroot/html", file), "tr") as f_in:
+            content = f_in.read()
+
+        # just a sanity check this is a file generated from a notebook
+        assert "<title>Notebook</title>" in content
+
+        # we assume only one "</body>" in file
+        assert content.count("</body>") == 1
+
+        # assume the snippet is not in there yet (in case we run this script
+        # repeatedly)
+        if GOOGLE_ANALYTICS in content:
+            # already injected
+            counter_untouched += 1
+        else:
+
+            # if so, inject google analytics snippet before end of body:
+            modified_content = content.replace("</body>", snippet + "\n</body>")
+
+            with open(os.path.join("../wwwroot/html", file), "tw") as f_out:
+                f_out.write(modified_content)
+
+            counter_injected += 1
+
+    assert len(files) == counter_untouched + counter_injected
+    print(f"{counter_injected} files injected, " +
+          f"and {counter_untouched} untouched")
+
+
+inject_google_analytics_into_html_notebooks(GOOGLE_ANALYTICS)
+


### PR DESCRIPTION
The html generated from ipynb files does not contain the google analytics snippet that pelican kindly embeds in its generated html.

Simple addition to the `publishconf.py` file, which is executed when using `make publish` in the `pelican` directory, to add this snippet to the html files.

There may well be more efficient and elegant ways to achieve this (maybe when the html of the notebook is created).

