### PR TITLE
Revert jquery version due to mobile bug

### DIFF
--- a/tools/pelican/themes/plumage/templates/base.html
+++ b/tools/pelican/themes/plumage/templates/base.html
@@ -22,7 +22,7 @@
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap-theme.min.css"/>
     {% endif %}
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.0/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
     <script src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
 
     <script type="text/javascript" class="init">


### PR DESCRIPTION
 The plumage navbar-toggle button breaks with higher versions of
 jquery, throws a "TypeError: can't convert b to string" error

Reverted jquery to the original version from the plumage theme