### PR TITLE
Table values are essentially ints, not floats

### DIFF
--- a/coronavirus/coronavirus.py
+++ b/coronavirus/coronavirus.py
@@ -253,7 +253,7 @@ def compose_dataframe_summary(cases, deaths):
     df["daily new deaths"] = deaths.diff()
 
     # drop first row with nan -> otherwise ints are shows as float in table
-    df = df.dropna()
+    df = df.dropna().astype(int)
 
     # change index: latest numbers shown first
     df = df[::-1]


### PR DESCRIPTION
Daily cases and deaths are now shown as `float` though actual values are `int`s. Float values in this context look a bit confusing for me.

![image](https://user-images.githubusercontent.com/1487169/82183981-2f7fe680-98e7-11ea-8bc3-da80aede7267.png)

This commit will fix the issue.