### PR TITLE
Fix lower limit for number of cases; y-ticks are now just numbers

### DIFF
--- a/coronavirus/coronavirus.py
+++ b/coronavirus/coronavirus.py
@@ -17,6 +17,7 @@ rcParams['font.family'] = 'sans-serif'
 rcParams['font.sans-serif'] = ['Inconsolata']
 # need many figures for index.ipynb and germany.ipynb
 rcParams['figure.max_open_warning'] = 50
+from matplotlib.ticker import ScalarFormatter
 
 import matplotlib.pyplot as plt
 plt.style.use('ggplot')
@@ -390,6 +391,7 @@ def plot_time_step(ax, series, style="-", logscale=True):
         ax.set_yscale('log')
     ax.legend()
     ax.set_ylabel("total numbers")
+    ax.yaxis.set_major_formatter(ScalarFormatter())
     return ax
 
 
@@ -878,6 +880,7 @@ def plot_logdiff_time(ax, df, xaxislabel, yaxislabel, style="", labels=True, lab
     ax.set_ylabel(yaxislabel)
     ax.set_xlabel(xaxislabel)
     ax.set_yscale('log')
+    ax.yaxis.set_major_formatter(ScalarFormatter())
     # ax.set_xscale('log')    # also interesting
     ax.set_ylim(bottom=v0)  # remove setting limit?, following
                               # https://github.com/fangohr/coronavirus-2020/issues/3
@@ -1034,20 +1037,26 @@ def make_compare_plot_germany(region_subregion,
 
     fig, axes = plt.subplots(2, 1, figsize=(10, 6))
     ax=axes[0]
+    res_c_0 = res_c[res_c.index >= 0]  # from "day 0" only
+        # if we have values in between 1 and 10, set the lower `yc_limit` on the graph to 1
+    if res_c_0[(res_c_0 >= 1) & (res_c_0 < 10)].any().any():
+        yc_limit = 1
+    else:
+        yc_limit = v0c
     plot_logdiff_time(ax, res_c, f"days since {v0c} cases",
                       "daily new cases\n(rolling 7-day mean)",
-                      v0=v0c, highlight={res_c.columns[0]:"C1"}, labeloffset=0.5)
+                      v0=yc_limit, highlight={res_c.columns[0]:"C1"}, labeloffset=0.5)
     ax = axes[1]
 
     res_d_0 = res_d[res_d.index >= 0]   # from "day 0" only
     # if we have values in between 0.1 and 1, set the lower `y_limit` on the graph to 0.1
     if res_d_0[(res_d_0 > 0.1) & (res_d_0 < 1)].any().any():    # there must be a more elegant check
-        y_limit = 0.1
+        yd_limit = 0.1
     else:
-        y_limit = v0d
+        yd_limit = v0d
     plot_logdiff_time(ax, res_d, f"days since {v0d} deaths",
                       "daily new deaths\n(rolling 7-day mean)",
-                      v0=y_limit, highlight={res_d.columns[0]:"C0"},
+                      v0=yd_limit, highlight={res_d.columns[0]:"C0"},
                       labeloffset=0.5)
 
     # fig.tight_layout(pad=1)

--- a/coronavirus/coronavirus.py
+++ b/coronavirus/coronavirus.py
@@ -17,7 +17,7 @@ rcParams['font.family'] = 'sans-serif'
 rcParams['font.sans-serif'] = ['Inconsolata']
 # need many figures for index.ipynb and germany.ipynb
 rcParams['figure.max_open_warning'] = 50
-from matplotlib.ticker import ScalarFormatter
+from matplotlib.ticker import ScalarFormatter, FuncFormatter
 from bisect import bisect
 
 import matplotlib.pyplot as plt
@@ -881,7 +881,9 @@ def plot_logdiff_time(ax, df, xaxislabel, yaxislabel, style="", labels=True, lab
     ax.set_ylabel(yaxislabel)
     ax.set_xlabel(xaxislabel)
     ax.set_yscale('log')
-    ax.yaxis.set_major_formatter(ScalarFormatter())
+    # use integer numbers for values > 1, and decimal presentation below
+    # from https://stackoverflow.com/questions/21920233/matplotlib-log-scale-tick-label-number-formatting/33213196
+    ax.yaxis.set_major_formatter(FuncFormatter(lambda y, _: '{:g}'.format(y)))
     # ax.set_xscale('log')    # also interesting
     ax.set_ylim(bottom=set_y_axis_limit(df, v0))
     ax.set_xlim(left=-1)  #ax.set_xlim(-1, df.index.max())


### PR DESCRIPTION
This MR addresses #33, though I'm not sure if I fixed all cares. I only checked Germany and a random country.

Also I added `ScalarFormatter` to improve readability of y-axis: now there are just numbers (1, 10, 100), not powers (10⁰, 10¹, 10²).

Before:
![image](https://user-images.githubusercontent.com/1487169/82318378-0a1ad780-99d0-11ea-9fee-0c8e47c5e212.png)

After:
![image](https://user-images.githubusercontent.com/1487169/82318494-3f272a00-99d0-11ea-836d-b4264c071b17.png)


Closes #33.