### PR TITLE
Fixes

### DIFF
--- a/tools/generate-individiual-plots.ipynb
+++ b/tools/generate-individiual-plots.ipynb
@@ -80,7 +80,7 @@
     "    # fig.savefig(outpath + '.png', dpi=250)\n",
     "    with open(\"pelican/content/pages/index-included-for-figure1-html\", \"tw\") as f:\n",
     "        f.write(f'<a href=\"html/{country}.html\">')\n",
-    "        f.write('<img src=\"{attach}fig-homepage-example-plot.svg\"></a>')\n",
+    "        f.write('<img class=\"noZoom img-responsive\" src=\"{attach}fig-homepage-example-plot.svg\"></a>')\n",
     "\n",
     "    return ax\n",
     "\n",
@@ -181,7 +181,7 @@
     "    # fig.savefig(outpath + '.png', dpi=250)\n",
     "    with open(\"pelican/content/pages/index-included-for-figure1-html\", \"tw\") as f:\n",
     "        f.write(f'<a href=\"html/{country}.html\">')\n",
-    "        f.write('<img src=\"{attach}fig-homepage-example-plot.svg\"></a>')\n",
+    "        f.write('<img class=\"noZoom img-responsive\" src=\"{attach}fig-homepage-example-plot.svg\"></a>')\n",
     "\n",
     "# save_frontpage_figure('United Kingdom')"
    ]

--- a/tools/pelican/themes/plumage/templates/base.html
+++ b/tools/pelican/themes/plumage/templates/base.html
@@ -28,7 +28,7 @@
     <script type="text/javascript" class="init">
       $(document).ready(function() {
           $('#data_table').DataTable( {
-              "order": [[ 1, "desc" ]]
+              "order": [[ 3, "desc" ]]
           } );
       } );
     </script>


### PR DESCRIPTION
Sets default sorting for tables to "new cases last week".

Disables zoom feature on the images embedded in the index as they should act as links to their respective notebooks.