### PR TITLE
Force py.test >=4.6 to work around CI bug with python 3.6 and 3.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ env:
     - MPLBACKEND=agg
 
 install:
-  #- make dev-install-upgrade-depedencies
+  - pip install -U pytest
   - make dev-install
+  
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
     - MPLBACKEND=agg
 
 install:
-  - make dev-install-upgrade-depedencies
-  #- make dev-install
+  #- make dev-install-upgrade-depedencies
+  - make dev-install
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ env:
     - MPLBACKEND=agg
 
 install:
-  - make dev-install
+  - make dev-install-upgrade-depedencies
+  #- make dev-install
+
 
 script:
   - make test

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(name="oscovida",
       ],
       extras_require={
           'test': [
-              'pytest>=4.6',
+              'pytest',
               'pytest-cov',
               'coverage',
               'nbval',

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(name="oscovida",
       ],
       extras_require={
           'test': [
-              'pytest',
+              'pytest>=4.6',
               'pytest-cov',
               'coverage',
               'nbval',


### PR DESCRIPTION
More of a diagnostic experiment than a fix